### PR TITLE
Fix rejecting rxjs Observables created from other window contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Fixes
+* Fixed mistakenly rejecting Observables from other contexts
+
 ## 0.0.48
 ### Fixes
 * Fixed `ac-circle-desc` radius changing.

--- a/src/angular-cesium/components/ac-layer/ac-layer.component.ts
+++ b/src/angular-cesium/components/ac-layer/ac-layer.component.ts
@@ -252,12 +252,19 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 		const acForArr = this.acFor.split(' ');
 		this.observable = this.context[acForArr[3]];
 		this.entityName = acForArr[1];
-		if (!this.observable || !(this.observable instanceof Observable)) {
+		if (!this.isObservable(this.observable)) {
 			throw  new Error('ac-layer: must initailize [acFor] with rx observable, instead received: ' + this.observable);
 		}
 
 		this.layerService.context = this.context;
 		this.layerService.setEntityName(this.entityName);
+	}
+
+	/** Test for a rxjs Observable */
+	private isObservable(obj: any): boolean {
+		/* check via duck-typing rather than instance of
+		 * to allow passing between window contexts */
+		return obj && typeof obj.subscribe === 'function'
 	}
 
 	ngAfterContentInit(): void {


### PR DESCRIPTION
**Changes** the instanceof check for rxjs to a duck-typing isObservable
method to fix mistakenly rejecting Observables from other contexts.

Window context issue: https://github.com/ReactiveX/rxjs/issues/2628

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] **Make sure all changes are documented in CHANGESLOG.md and README.md**

I didn't want to bump the version number so I listed the fix under unreleased.