### PR TITLE
CZML Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ tmp
 .DS_Store
 src/client/app/shared/config/env.config.js
 src/client/app/shared/config/env.config.js.map
+.vscode/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Features
+* New `<ac-czml-desc>` component for adding CzmlDataSource to ac-layer.
+* New `czml-drawer` service 
+* New `<czml-layer` component in demo app to show usage of `<ac-czml-desc>``
+
 ## 0.0.51
 ### Fixes
 * Fix `package.json` engines section. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Features
 * New `<ac-czml-desc>` component for adding CzmlDataSource to ac-layer.
 * New `czml-drawer` service 
-* New `<czml-layer` component in demo app to show usage of `<ac-czml-desc>``
+* New `<czml-layer` component in demo app to show usage of `<ac-czml-desc>`
 
 ## 0.0.51
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ After explaining a little bit about `ac-layer` we hope that you may see it's ben
 + rectangle -[`ac-rectangle-dec`](https://tgftech.github.io/angular-cesium/components/AcRectangleDescComponent.html)
 * html - [`ac-html-desc`](https://tgftech.github.io/angular-cesium/components/AcHtmlDescComponent.html) / [`ac-html`](https://tgftech.github.io/angular-cesium/components/AcHtmlComponent.html)
 * array - [`ac-array-desc`](https://tgftech.github.io/angular-cesium/components/AcArrayDescComponent.html)
+* czmlPacket - [`ac-czml-desc`](https://tgftech.github.io/angular-cesium/components/AcCzmlDescComponent.html)
 
 ### `ac-entity-desc` vs `ac-entity`
 + `ac-entity-desc` component is used to describe how each entity / array of entities in a stream of entities, managed inside `ac-layer`, should be drawn.

--- a/demo/app/app.module.ts
+++ b/demo/app/app.module.ts
@@ -45,6 +45,7 @@ import { AngularCesiumWidgetsModule } from '../../src/angular-cesium-widgets/ang
 import { ToolbarExampleComponent } from './components/toolbar-example/toolbar-example.component';
 import { BoxesLayerComponent } from './components/boxes-layer/boxes-layer.component';
 import { TrackEntityLayerComponent } from './components/track-entity-layer/track-entity-layer.component';
+import { CzmlLayerComponent } from './components/czml-layer/czml-layer.component';
 
 
 @NgModule({
@@ -86,6 +87,7 @@ import { TrackEntityLayerComponent } from './components/track-entity-layer/track
     ToolbarExampleComponent,
     BoxesLayerComponent,
     TrackEntityLayerComponent,
+    CzmlLayerComponent,
   ],
   imports: [
     BrowserModule,

--- a/demo/app/components/czml-layer/czml-layer.component.html
+++ b/demo/app/components/czml-layer/czml-layer.component.html
@@ -1,0 +1,4 @@
+<ac-layer acFor="let czmlPacket of czmlPackets$" [context]="this" [show]="show">
+    <ac-czml-desc props="{ czmlPacket : czmlPacket}">
+    </ac-czml-desc>
+</ac-layer>

--- a/demo/app/components/czml-layer/czml-layer.component.ts
+++ b/demo/app/components/czml-layer/czml-layer.component.ts
@@ -7,6 +7,7 @@ import { AcEntity } from '../../../../src/angular-cesium/models/ac-entity';
 import { AcNotification } from '../../../../src/angular-cesium/models/ac-notification';
 import { ActionType } from '../../../../src/angular-cesium/models/action-type.enum';
 import { ViewerConfiguration } from '../../../../src/angular-cesium/services/viewer-configuration/viewer-configuration.service';
+import { MapsManagerService } from '../../../../src/angular-cesium';
 
 @Component({
   selector: 'czml-layer',
@@ -19,7 +20,7 @@ export class CzmlLayerComponent implements OnInit {
   show = true;
   updater = new Subscriber<AcNotification>();
 
-  constructor() { }
+  constructor(private mapsManagerService: MapsManagerService) { }
 
   ngOnInit() {
 
@@ -76,7 +77,7 @@ export class CzmlLayerComponent implements OnInit {
       }
     }
 
- 
+
 
     this.czmlPackets$ = new Observable(observer => {
       this.updater = observer;
@@ -102,28 +103,6 @@ export class CzmlLayerComponent implements OnInit {
         entity: new AcEntity(packet2),
         actionType: ActionType.ADD_UPDATE
       })
-
-
-      // after 3 seconds, update outlineColor of point 2 
-      setTimeout(() => {
-
-        // providing an object that only contains the diff 
-        const updatePoint2 = {
-          id: "point_2",
-          point: {
-            outlineColor: {
-              rgba: [0, 0, 255, 200]
-            }
-          }
-        }
-
-        this.updater.next({
-          id: updatePoint2.id,
-          entity: new AcEntity(updatePoint2),
-          actionType: ActionType.ADD_UPDATE
-        })
-
-      }, 3000);
 
       // after 4 seconds, remove point 1
       setTimeout(() => {
@@ -190,11 +169,36 @@ export class CzmlLayerComponent implements OnInit {
 
       }, 10000);
 
+      // after 11 seconds, update outlineColor of point 2 
+      setTimeout(() => {
+
+        // providing an object that only contains the diff 
+        const updatePoint2 = {
+          id: 'point_2',
+          point: {
+            outlineColor: {
+              rgba: [0, 0, 255, 200]
+            }
+          }
+        }
+
+        this.updater.next({
+          id: updatePoint2.id,
+          entity: new AcEntity(updatePoint2),
+          actionType: ActionType.ADD_UPDATE
+        })
+
+        this.zoomOnDataSource();
+      }, 11000);
 
     })
 
+  }
 
 
-
+  zoomOnDataSource() {
+    const czmlDataSources = this.layer.getDrawerDataSourcesByName('czml');
+    const viewer = this.mapsManagerService.getMap().getCesiumViewer();
+    viewer.flyTo(czmlDataSources[0].entities);
   }
 }

--- a/demo/app/components/czml-layer/czml-layer.component.ts
+++ b/demo/app/components/czml-layer/czml-layer.component.ts
@@ -1,0 +1,200 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { Subscriber } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
+
+import { AcLayerComponent } from '../../../../src/angular-cesium/components/ac-layer/ac-layer.component';
+import { AcEntity } from '../../../../src/angular-cesium/models/ac-entity';
+import { AcNotification } from '../../../../src/angular-cesium/models/ac-notification';
+import { ActionType } from '../../../../src/angular-cesium/models/action-type.enum';
+import { ViewerConfiguration } from '../../../../src/angular-cesium/services/viewer-configuration/viewer-configuration.service';
+
+@Component({
+  selector: 'czml-layer',
+  templateUrl: 'czml-layer.component.html',
+})
+export class CzmlLayerComponent implements OnInit {
+  @ViewChild(AcLayerComponent) layer: AcLayerComponent;
+
+  czmlPackets$: Observable<AcNotification>;
+  show = true;
+  updater = new Subscriber<AcNotification>();
+
+  constructor() { }
+
+  ngOnInit() {
+
+    const document = {
+      "id": "document",
+      "version": "1.0"
+    };
+
+    const packet1 = {
+      "id": "point_1",
+      "availability": "2012-08-04T16:00:00Z/2012-08-04T16:05:00Z",
+      "position": {
+        "epoch": "2012-08-04T16:00:00Z",
+        "cartographicDegrees": [
+          0, -70, 20, 150000,
+          100, -80, 44, 150000,
+          200, -90, 18, 150000,
+          300, -98, 52, 150000
+        ]
+      },
+      "point": {
+        "color": {
+          "rgba": [255, 255, 255, 200]
+        },
+        "outlineColor": {
+          "rgba": [255, 0, 0, 200]
+        },
+        "outlineWidth": 3,
+        "pixelSize": 15
+      }
+    }
+
+    const packet2 = {
+      "id": "point_2",
+      "availability": "2012-08-04T16:00:00Z/2012-08-04T16:05:00Z",
+      "position": {
+        "epoch": "2012-08-04T16:00:00Z",
+        "cartographicDegrees": [
+          0, -70, 25, 150000,
+          100, -80, 44, 150000,
+          200, -90, 18, 150000,
+          300, -98, 52, 150000
+        ]
+      },
+      "point": {
+        "color": {
+          "rgba": [255, 255, 255, 200]
+        },
+        "outlineColor": {
+          "rgba": [0, 255, 0, 200]
+        },
+        "outlineWidth": 3,
+        "pixelSize": 15
+      }
+    }
+
+ 
+
+    this.czmlPackets$ = new Observable(observer => {
+      this.updater = observer;
+
+      // Attention, first packet needs to be a document
+      // Example: https://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=CZML%20Point%20-%20Time%20Dynamic.html&label=CZML
+      this.updater.next({
+        id: document.id,
+        entity: new AcEntity(document),
+        actionType: ActionType.ADD_UPDATE
+      })
+
+      // add point 1 
+      this.updater.next({
+        id: packet1.id,
+        entity: new AcEntity(packet1),
+        actionType: ActionType.ADD_UPDATE
+      })
+
+      // add point 2
+      this.updater.next({
+        id: packet2.id,
+        entity: new AcEntity(packet2),
+        actionType: ActionType.ADD_UPDATE
+      })
+
+
+      // after 3 seconds, update outlineColor of point 2 
+      setTimeout(() => {
+
+        // providing an object that only contains the diff 
+        const updatePoint2 = {
+          id: "point_2",
+          point: {
+            outlineColor: {
+              rgba: [0, 0, 255, 200]
+            }
+          }
+        }
+
+        this.updater.next({
+          id: updatePoint2.id,
+          entity: new AcEntity(updatePoint2),
+          actionType: ActionType.ADD_UPDATE
+        })
+
+      }, 3000);
+
+      // after 4 seconds, remove point 1
+      setTimeout(() => {
+        this.layer.remove('point_1')
+      }, 4000);
+
+      // after 5 seconds, update color and reset outlineColor of point 2 
+      setTimeout(() => {
+
+        // changing the initial packet2
+        packet2.point.color.rgba = [0, 0, 255, 200]
+
+        this.updater.next({
+          id: packet2.id,
+          entity: new AcEntity(packet2),
+          actionType: ActionType.ADD_UPDATE
+        })
+
+      }, 5000);
+
+      // after 6 seconds add point 1 again 
+      setTimeout(() => {
+
+        // add point 1 
+        this.updater.next({
+          id: packet1.id,
+          entity: new AcEntity(packet1),
+          actionType: ActionType.ADD_UPDATE
+        })
+
+      }, 6000);
+
+      // after 7 seconds, hide the layer 
+      setTimeout(() => {
+        this.show = false;
+      }, 7000);
+
+      // after 8 seconds, show the layer 
+      setTimeout(() => {
+        this.show = true;
+      }, 8000);
+
+      // after 9 seconds, remove all 
+      setTimeout(() => {
+        this.layer.removeAll()
+      }, 9000);
+
+      // after 10 seconds add points 1 and 2 again 
+      setTimeout(() => {
+
+        // add point 1 
+        this.updater.next({
+          id: packet1.id,
+          entity: new AcEntity(packet1),
+          actionType: ActionType.ADD_UPDATE
+        })
+
+        // add point 2
+        this.updater.next({
+          id: packet2.id,
+          entity: new AcEntity(packet2),
+          actionType: ActionType.ADD_UPDATE
+        })
+
+      }, 10000);
+
+
+    })
+
+
+
+
+  }
+}

--- a/demo/app/components/demo-map/demo-map.component.html
+++ b/demo/app/components/demo-map/demo-map.component.html
@@ -22,6 +22,7 @@
     <!--<dynamic-circle-layer #layer></dynamic-circle-layer>-->
     <!--<dynamic-polyline-layer #layer></dynamic-polyline-layer>-->
     <!--<point-layer></point-layer>-->
+    <!--<czml-layer></czml-layer>-->
     <!--<event-test-layer></event-test-layer>-->
     <!--<arc-layer #layer></arc-layer>-->
     <!--<draw-on-map-layer></draw-on-map-layer>-->

--- a/demo/app/components/demo-map/demo-map.component.ts
+++ b/demo/app/components/demo-map/demo-map.component.ts
@@ -25,6 +25,7 @@ export class DemoMapComponent {
 			fullscreenButton : false,
 			baseLayerPicker : false,
 			animation : false,
+			shouldAnimate: false,
 			homeButton : false,
 			geocoder : false,
 			navigationHelpButton : false,

--- a/src/angular-cesium/angular-cesium.module.ts
+++ b/src/angular-cesium/angular-cesium.module.ts
@@ -59,6 +59,7 @@ import { AcContextMenuWrapperComponent } from './components/ac-context-menu-wrap
 import { AcArrayDescComponent } from './components/ac-array-desc/ac-array-desc.component';
 import { AcPointPrimitiveDescComponent } from './components/ac-point-primitive-desc/ac-point-primitive-desc.component';
 import { AcPrimitivePolylineComponent } from './components/ac-primitive-polyline/ac-primitive-polyline.component';
+import { AcCzmlDescComponent } from './components/ac-czml-desc/ac-czml-desc.component';
 
 @NgModule({
   imports: [
@@ -110,6 +111,7 @@ import { AcPrimitivePolylineComponent } from './components/ac-primitive-polyline
     AcHtmlDirective,
     AcHtmlContainerDirective,
     AcArrayDescComponent,
+    AcCzmlDescComponent,
 
     AcStaticEllipseDescComponent,
     AcDynamicEllipseDescComponent,
@@ -159,6 +161,7 @@ import { AcPrimitivePolylineComponent } from './components/ac-primitive-polyline
 		AcPointPrimitiveDescComponent,
     AcHtmlDescComponent,
     AcArrayDescComponent,
+    AcCzmlDescComponent,
 
     AcStaticEllipseDescComponent,
     AcDynamicEllipseDescComponent,

--- a/src/angular-cesium/components/ac-czml-desc/ac-czml-desc.component.ts
+++ b/src/angular-cesium/components/ac-czml-desc/ac-czml-desc.component.ts
@@ -1,0 +1,45 @@
+import { Component, OnInit } from '@angular/core';
+
+import { BasicDesc } from '../../services/basic-desc/basic-desc.service';
+import { CesiumProperties } from '../../services/cesium-properties/cesium-properties.service';
+import { ComputationCache } from '../../services/computation-cache/computation-cache.service';
+import { CzmlDrawerService } from '../../services/drawers/czml-drawer/czml-drawer.service';
+import { LayerService } from '../../services/layer-service/layer-service.service';
+import { AcEntity } from '../../models/ac-entity';
+
+/**
+ *  This is a czml implementation.
+ *  The ac-czml-desc element must be a child of ac-layer element.
+ *
+ *  See CZML Guide for the structure of props.czmlPacket:
+ *  + https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/CZML-Structure
+ *  
+ *  Attention: the first czmlPacket in the stream needs to be a document
+ *  with an id and a name attribute. See this example
+ *  + https://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=CZML%20Point%20-%20Time%20Dynamic.html&label=CZML
+ * 
+ *  To see a working example, use the demo app and 
+ *  + uncomment <czml-layer></czml-layer> in demo-map.component.html
+ *  + set the properties 'timeline', 'animation' and 'shouldAnimate' true in viewerOptions of demo-map.component.ts
+ *   
+ * 
+ *  __Usage:__
+ *  ```
+ *    <ac-czml-desc props="{
+ *      czmlPacket: czmlPacket
+ *    }">
+ *	  </ac-czml-desc>
+ *  ```
+ */
+@Component({
+  selector: 'ac-czml-desc',
+  template: '',
+})
+export class AcCzmlDescComponent extends BasicDesc implements OnInit {
+  constructor(czmlDrawer: CzmlDrawerService, layerService: LayerService,
+    computationCache: ComputationCache, cesiumProperties: CesiumProperties) {
+    super(czmlDrawer, layerService, computationCache, cesiumProperties);
+  }
+
+  
+}

--- a/src/angular-cesium/components/ac-layer/ac-layer.component.ts
+++ b/src/angular-cesium/components/ac-layer/ac-layer.component.ts
@@ -284,11 +284,11 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 			const initOptions = this.options ? this.options[drawerName] : undefined;
 			const drawerDataSources = drawer.init(initOptions);
 			// only entities drawers create data sources
-			// TODO: Causes Bad Performance
-			// if (drawerDataSources) {
-			// this.mapLayersService.registerLayerDataSources(drawerDataSources, this.zIndex);
-			// this.layerDrawerDataSources.push(...drawerDataSources);
-			// }
+			if (drawerDataSources) {
+				// this.mapLayersService.registerLayerDataSources(drawerDataSources, this.zIndex);
+				// TODO: Check if the following line causes Bad Performance
+				this.layerDrawerDataSources.push(...drawerDataSources);
+			}
 			drawer.setShow(this.show);
 		});
 	}
@@ -318,6 +318,23 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 	}
 
 	/**
+	 * Returns an array of DataSources registered by a drawer of this layer 
+	 * @return Array of Cesium.DataSources 
+	 */
+	getLayerDrawerDataSources(): any[] {
+		return this.layerDrawerDataSources;
+	}
+
+	/**
+	 * Returns an Array of DataSources of the drawer with the provided DataSource.name 
+	 * Example: getDataSourceOfDrawer('polyline') returns the dataSource of polyline drawer
+	 * @return Array of Cesium.DataSources 
+	 */
+	getDrawerDataSourcesByName(name: string): any[] {
+		return this.layerDrawerDataSources.filter(d => d.name === name);
+	}
+
+	/**
 	 * Returns the store.
 	 */
 	getStore(): Map<string, any> {
@@ -331,7 +348,7 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 		this.layerService.getDescriptions().forEach((description) => description.removeAll());
 		this.entitiesStore.clear();
 	}
- 
+
 	/**
 	 * remove entity from the layer
 	 * @param {number} entityId

--- a/src/angular-cesium/components/ac-layer/ac-layer.component.ts
+++ b/src/angular-cesium/components/ac-layer/ac-layer.component.ts
@@ -1,8 +1,8 @@
 // tslint:disable
 import { BillboardDrawerService } from '../../services/drawers/billboard-drawer/billboard-drawer.service';
 import {
-  AfterContentInit, ChangeDetectionStrategy, Component, Input, OnChanges, OnDestroy, OnInit,
-  SimpleChanges
+	AfterContentInit, ChangeDetectionStrategy, Component, Input, OnChanges, OnDestroy, OnInit,
+	SimpleChanges
 } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -39,6 +39,7 @@ import { BillboardPrimitiveDrawerService } from '../../services/drawers/billboar
 import { MapLayersService } from '../../services/map-layers/map-layers.service';
 import { PointPrimitiveDrawerService } from '../../services/drawers/point-primitive-drawer/point-primitive-drawer.service';
 import { HtmlDrawerService } from '../../services/drawers/html-drawer/html-drawer.service';
+import { CzmlDrawerService } from '../../services/drawers/czml-drawer/czml-drawer.service';
 
 // tslint:enable
 /**
@@ -77,9 +78,9 @@ import { HtmlDrawerService } from '../../services/drawers/html-drawer/html-drawe
  *  ```
  */
 @Component({
-	selector : 'ac-layer',
-	template : '<ng-content></ng-content>',
-	providers : [
+	selector: 'ac-layer',
+	template: '<ng-content></ng-content>',
+	providers: [
 		LayerService,
 		ComputationCache,
 		BillboardDrawerService,
@@ -102,6 +103,7 @@ import { HtmlDrawerService } from '../../services/drawers/html-drawer/html-drawe
 		BillboardPrimitiveDrawerService,
 		PointPrimitiveDrawerService,
 		HtmlDrawerService,
+		CzmlDrawerService,
 
 		DynamicEllipseDrawerService,
 		DynamicPolylineDrawerService,
@@ -135,36 +137,37 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 	private entitiesStore = new Map<string, any>();
 	private layerDrawerDataSources: any[] = [];
 
-	constructor(private  layerService: LayerService,
-							private _computationCache: ComputationCache,
-							private mapLayersService: MapLayersService,
-							billboardDrawerService: BillboardDrawerService,
-							labelDrawerService: LabelDrawerService,
-							ellipseDrawerService: EllipseDrawerService,
-							polylineDrawerService: PolylineDrawerService,
-							polygonDrawerService: PolygonDrawerService,
-							arcDrawerService: ArcDrawerService,
-							pointDrawerService: PointDrawerService,
-							modelDrawerService: ModelDrawerService,
-							boxDrawerService: BoxDrawerService,
-							corridorDrawerService: CorridorDrawerService,
-							cylinderDrawerService: CylinderDrawerService,
-							ellipsoidDrawerSerice: EllipsoidDrawerService,
-							polylineVolumeDrawerService: PolylineVolumeDrawerService,
-							wallDrawerService: WallDrawerService,
-							rectangleDrawerService: RectangleDrawerService,
-							dynamicEllipseDrawerService: DynamicEllipseDrawerService,
-							dynamicPolylineDrawerService: DynamicPolylineDrawerService,
-							staticCircleDrawerService: StaticCircleDrawerService,
-							staticPolylineDrawerService: StaticPolylineDrawerService,
-							staticPolygonDrawerService: StaticPolygonDrawerService,
-							staticEllipseDrawerService: StaticEllipseDrawerService,
-							polylinePrimitiveDrawerService: PolylinePrimitiveDrawerService,
-							labelPrimitiveDrawerService: LabelPrimitiveDrawerService,
-							billboardPrimitiveDrawerService: BillboardPrimitiveDrawerService,
-							pointPrimitiveDrawerService: PointPrimitiveDrawerService,
-							htmlDrawerService: HtmlDrawerService
-							) {
+	constructor(private layerService: LayerService,
+		private _computationCache: ComputationCache,
+		private mapLayersService: MapLayersService,
+		billboardDrawerService: BillboardDrawerService,
+		labelDrawerService: LabelDrawerService,
+		ellipseDrawerService: EllipseDrawerService,
+		polylineDrawerService: PolylineDrawerService,
+		polygonDrawerService: PolygonDrawerService,
+		arcDrawerService: ArcDrawerService,
+		pointDrawerService: PointDrawerService,
+		modelDrawerService: ModelDrawerService,
+		boxDrawerService: BoxDrawerService,
+		corridorDrawerService: CorridorDrawerService,
+		cylinderDrawerService: CylinderDrawerService,
+		ellipsoidDrawerSerice: EllipsoidDrawerService,
+		polylineVolumeDrawerService: PolylineVolumeDrawerService,
+		wallDrawerService: WallDrawerService,
+		rectangleDrawerService: RectangleDrawerService,
+		dynamicEllipseDrawerService: DynamicEllipseDrawerService,
+		dynamicPolylineDrawerService: DynamicPolylineDrawerService,
+		staticCircleDrawerService: StaticCircleDrawerService,
+		staticPolylineDrawerService: StaticPolylineDrawerService,
+		staticPolygonDrawerService: StaticPolygonDrawerService,
+		staticEllipseDrawerService: StaticEllipseDrawerService,
+		polylinePrimitiveDrawerService: PolylinePrimitiveDrawerService,
+		labelPrimitiveDrawerService: LabelPrimitiveDrawerService,
+		billboardPrimitiveDrawerService: BillboardPrimitiveDrawerService,
+		pointPrimitiveDrawerService: PointPrimitiveDrawerService,
+		htmlDrawerService: HtmlDrawerService,
+		czmlDrawerService: CzmlDrawerService
+	) {
 		this._drawerList = new Map([
 			['billboard', billboardDrawerService],
 			['label', labelDrawerService],
@@ -186,6 +189,7 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 			['billboardPrimitive', billboardPrimitiveDrawerService],
 			['pointPrimitive', pointPrimitiveDrawerService],
 			['html', htmlDrawerService],
+			['czml', czmlDrawerService],
 
 			['dynamicEllipse', dynamicEllipseDrawerService],
 			['dynamicPolyline', dynamicPolylineDrawerService],
@@ -253,7 +257,7 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 		this.observable = this.context[acForArr[3]];
 		this.entityName = acForArr[1];
 		if (!this.isObservable(this.observable)) {
-			throw  new Error('ac-layer: must initailize [acFor] with rx observable, instead received: ' + this.observable);
+			throw new Error('ac-layer: must initailize [acFor] with rx observable, instead received: ' + this.observable);
 		}
 
 		this.layerService.context = this.context;
@@ -272,7 +276,7 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 	}
 
 	ngOnInit(): void {
-    this.layerService.context = this.context;
+		this.layerService.context = this.context;
 		this.layerService.options = this.options;
 		this.layerService.show = this.show;
 		this.layerService.zIndex = this.zIndex;
@@ -280,11 +284,11 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 			const initOptions = this.options ? this.options[drawerName] : undefined;
 			const drawerDataSources = drawer.init(initOptions);
 			// only entities drawers create data sources
-      // TODO: Causes Bad Performance
-      // if (drawerDataSources) {
-				// this.mapLayersService.registerLayerDataSources(drawerDataSources, this.zIndex);
-				// this.layerDrawerDataSources.push(...drawerDataSources);
-      // }
+			// TODO: Causes Bad Performance
+			// if (drawerDataSources) {
+			// this.mapLayersService.registerLayerDataSources(drawerDataSources, this.zIndex);
+			// this.layerDrawerDataSources.push(...drawerDataSources);
+			// }
 			drawer.setShow(this.show);
 		});
 	}
@@ -292,13 +296,13 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 	ngOnChanges(changes: SimpleChanges): void {
 		if (changes.show && !changes.show.firstChange) {
 			const showValue = changes['show'].currentValue;
-      this.layerService.show = showValue;
+			this.layerService.show = showValue;
 			this._drawerList.forEach((drawer) => drawer.setShow(showValue));
 		}
 
 		if (changes.zIndex && !changes.zIndex.firstChange) {
 			const zIndexValue = changes['zIndex'].currentValue;
-      this.layerService.zIndex = zIndexValue;
+			this.layerService.zIndex = zIndexValue;
 			this.mapLayersService.updateAndRefresh(this.layerDrawerDataSources, zIndexValue);
 		}
 	}
@@ -309,9 +313,9 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 		this.removeAll();
 	}
 
-  getLayerService(): LayerService {
-    return this.layerService;
-  }
+	getLayerService(): LayerService {
+		return this.layerService;
+	}
 
 	/**
 	 * Returns the store.
@@ -327,13 +331,13 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 		this.layerService.getDescriptions().forEach((description) => description.removeAll());
 		this.entitiesStore.clear();
 	}
-
+ 
 	/**
 	 * remove entity from the layer
 	 * @param {number} entityId
 	 */
 	remove(entityId: string) {
-		this._updateStream.next({id : entityId, actionType : ActionType.DELETE});
+		this._updateStream.next({ id: entityId, actionType: ActionType.DELETE });
 		this.entitiesStore.delete(entityId);
 	}
 
@@ -351,7 +355,7 @@ export class AcLayerComponent implements OnInit, OnChanges, AfterContentInit, On
 	 * @param {number} id
 	 */
 	update(entity: AcEntity, id: string): void {
-		this._updateStream.next({entity, id, actionType : ActionType.ADD_UPDATE});
+		this._updateStream.next({ entity, id, actionType: ActionType.ADD_UPDATE });
 	}
 
 	refreshAll(collection: AcNotification[]): void {

--- a/src/angular-cesium/components/ac-map/ac-map.component.ts
+++ b/src/angular-cesium/components/ac-map/ac-map.component.ts
@@ -21,6 +21,7 @@ import { ScreenshotService } from '../../services/screenshot/screenshot.service'
 import { ContextMenuService } from '../../services/context-menu/context-menu.service';
 import { CoordinateConverter } from '../../services/coordinate-converter/coordinate-converter.service';
 import {PolylinePrimitiveDrawerService} from '../../services/drawers/polyline-primitive-drawer/polyline-primitive-drawer.service'
+import { CzmlDrawerService } from '../../services/drawers/czml-drawer/czml-drawer.service';
 
 /**
  * This is a map implementation, creates the cesium map.
@@ -56,7 +57,8 @@ import {PolylinePrimitiveDrawerService} from '../../services/drawers/polyline-pr
     EllipseDrawerService,
     PointDrawerService,
     ArcDrawerService,
-    PolygonDrawerService,
+    CzmlDrawerService,
+    PolygonDrawerService,    
     MapLayersService,
     CameraService,
 		ScreenshotService,
@@ -106,6 +108,7 @@ export class AcMapComponent implements OnChanges, OnInit, AfterViewInit {
               private polygonDrawerService: PolygonDrawerService,
               private arcDrawerService: ArcDrawerService,
               private pointDrawerService: PointDrawerService,
+              private czmlDrawerService: CzmlDrawerService,
               private mapEventsManager: MapEventsManagerService,
               private keyboardControlService: KeyboardControlService,
               private mapLayersService: MapLayersService,
@@ -125,7 +128,8 @@ export class AcMapComponent implements OnChanges, OnInit, AfterViewInit {
 		this.polylineDrawerService.init();
 		this.polygonDrawerService.init();
 		this.arcDrawerService.init();
-		this.pointDrawerService.init();
+    this.pointDrawerService.init();
+    this.czmlDrawerService.init();
 		this.keyboardControlService.init();
     this.contextMenuService.init(this.mapEventsManager);
   }

--- a/src/angular-cesium/services/drawers/czml-drawer/czml-drawer.service.ts
+++ b/src/angular-cesium/services/drawers/czml-drawer/czml-drawer.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@angular/core';
+
+import { CesiumService } from '../../cesium/cesium.service';
+import { BasicDrawerService } from '../basic-drawer/basic-drawer.service';
+
+/**
+ *  This drawer is responsible for drawing czml dataSources.
+ */
+@Injectable()
+export class CzmlDrawerService extends BasicDrawerService {
+
+    czmlStream: any;
+
+    constructor(
+        private cesiumService: CesiumService,
+    ) {
+        super();
+    }
+
+
+    init() {
+        const dataSources = [];
+
+        this.czmlStream = new Cesium.CzmlDataSource();
+
+        dataSources.push(this.czmlStream);
+
+        this.cesiumService.getViewer().dataSources.add(this.czmlStream);
+
+        return dataSources;
+    }
+
+    // returns the packet, provided by the stream
+    add(cesiumProps: any): any {
+
+        this.czmlStream.process(cesiumProps.czmlPacket);
+
+        return cesiumProps;
+    }
+
+    update(entity: any, cesiumProps: any) {
+        this.czmlStream.process(cesiumProps.czmlPacket);
+    }
+
+    remove(entity: any) {
+        this.czmlStream.entities.removeById(entity.acEntity.id)        
+    }
+
+    removeAll() {
+        this.czmlStream.entities.removeAll();        
+    }
+
+    setShow(showValue: boolean) {
+        this.czmlStream.entities.show = showValue;
+    }
+
+}
+
+

--- a/src/angular-cesium/services/drawers/czml-drawer/czml-drawer.service.ts
+++ b/src/angular-cesium/services/drawers/czml-drawer/czml-drawer.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { CesiumService } from '../../cesium/cesium.service';
 import { BasicDrawerService } from '../basic-drawer/basic-drawer.service';
+import { EntitiesDrawerOptions } from '../../../models/entities-drawer-options';
 
 /**
  *  This drawer is responsible for drawing czml dataSources.
@@ -18,10 +19,10 @@ export class CzmlDrawerService extends BasicDrawerService {
     }
 
 
-    init() {
+    init(options?: EntitiesDrawerOptions) {
         const dataSources = [];
 
-        this.czmlStream = new Cesium.CzmlDataSource();
+        this.czmlStream = new Cesium.CzmlDataSource('czml');
 
         dataSources.push(this.czmlStream);
 
@@ -43,11 +44,11 @@ export class CzmlDrawerService extends BasicDrawerService {
     }
 
     remove(entity: any) {
-        this.czmlStream.entities.removeById(entity.acEntity.id)        
+        this.czmlStream.entities.removeById(entity.acEntity.id)
     }
 
     removeAll() {
-        this.czmlStream.entities.removeAll();        
+        this.czmlStream.entities.removeAll();
     }
 
     setShow(showValue: boolean) {

--- a/src/angular-cesium/services/drawers/entities-drawer/entities-drawer.service.ts
+++ b/src/angular-cesium/services/drawers/entities-drawer/entities-drawer.service.ts
@@ -39,7 +39,7 @@ export class EntitiesDrawerService extends BasicDrawerService {
     const finalOptions = options || this.defaultOptions;
     const dataSources = [];
     for (let i = 0; i < finalOptions.collectionsNumber; i++) {
-      const dataSource = new Cesium.CustomDataSource();
+      const dataSource = new Cesium.CustomDataSource(this.graphicsTypeName);
 			dataSources.push(dataSource);
       this.cesiumService.getViewer().dataSources.add(dataSource);
       this.entityCollections.set(dataSource.entities,


### PR DESCRIPTION
This PR aims to add CZML Support.

**Why** 
CZML provides an easy way to create time dynamic entities (see [CZML Guide](https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/CZML-Guide) and [Cesium.CzmlDataSource](https://cesiumjs.org/Cesium/Build/Documentation/CzmlDataSource.html?classFilter=Czm) or this [example](https://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=CZML%20Point%20-%20Time%20Dynamic.html&label=CZML)).

Currently it is not possible to use CZML / Cesium.CzmlDataSource with ac-layer (see #231). 

**How** 
This PR adds
* New `<ac-czml-desc>` component that accepts a stream of CZML packets.
* New `czml-drawer` service that processes and draws CZML packets to CesiumViewer.
* New `<czml-layer>` component in demo app that shows usage of `<ac-czml-desc>`.

**Remarks** 

To see a working example, use the demo app and do this:
- Uncomment `<czml-layer></czml-layer>` in `demo-map.component.html`
- In `viewerOptions` of `demo-map.component.ts` enable `timeline`, `animation` and `shouldAnimate` by setting their values true

`czml-drawer` service does not use OptimizedEntityCollection (to keep things simple). I don't know the implications, please pay special attention to this aspect when reviewing the PR.