### PR TITLE
Angular 6 AOT support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,17 @@ lib
 test
 tmp
 
+# VS Code files
+.vscode/*
+
 # OS X trash files
 .DS_Store
 src/client/app/shared/config/env.config.js
 src/client/app/shared/config/env.config.js.map
+
+# Bundle files
+*.js
+*.map
+*.d.ts
+*.metadata.json
+*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Fixes
+* Fixed Angular 6 AOT Compilation error  [#244](https://github.com/TGFTech/angular-cesium/issues/224) by removing angular2parse dependency and adding a angular-parse folder instead
+
 ## 0.0.52
 ### Fixes
 * Fixed shape editors 2D points bug - remove height reference

--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ for webpack users try [this](https://cesiumjs.org/2016/01/26/Cesium-and-Webpack/
     $ open http://localhost:8080
     ```
 + More demos:
-  + [GeoStrike](http://geo-strike.com)
-  + [GLO](https://glo.now.sh)
+  + [GeoStrike](http://geo-strike.com) - [Repository](https://github.com/Webiks/GeoStrike)
+  + [GLO](https://glo.now.sh) - [Repository](https://github.com/sofwerx/glo-demo)
+  + [Safehouse](https://github.com/sofwerx/safehouse)
+  + [IMS](https://github.com/davidyaha/ims-workshop)
 
 ## Basic example
 

--- a/src/angular-cesium/angular-cesium.module.ts
+++ b/src/angular-cesium/angular-cesium.module.ts
@@ -6,7 +6,6 @@ import { AcBillboardComponent } from './components/ac-billboard/ac-billboard.com
 import { AcBillboardDescComponent } from './components/ac-billborad-desc/ac-billborad-desc.component';
 import { AcEllipseDescComponent } from './components/ac-ellipse-desc/ac-ellipse-desc.component';
 import { AcPolylineDescComponent } from './components/ac-polyline-desc/ac-polyline-desc.component';
-import { Angular2ParseModule } from 'angular2parse';
 import { PixelOffsetPipe } from './pipes/pixel-offset/pixel-offset.pipe';
 import { RadiansToDegreesPipe } from './pipes/radians-to-degrees/radians-to-degrees.pipe';
 import { JsonMapper } from './services/json-mapper/json-mapper.service';
@@ -63,7 +62,6 @@ import { AcPrimitivePolylineComponent } from './components/ac-primitive-polyline
 @NgModule({
   imports: [
     CommonModule,
-    Angular2ParseModule,
     UtilsModule,
   ],
   declarations: [

--- a/src/angular-parse/angular.ts
+++ b/src/angular-parse/angular.ts
@@ -1,0 +1,2 @@
+export * from './angular/compiler';
+export * from './angular/facade';

--- a/src/angular-parse/angular/compiler.ts
+++ b/src/angular-parse/angular/compiler.ts
@@ -1,0 +1,6 @@
+export * from './compiler/assertions';
+export * from './compiler/ast';
+export * from './compiler/chars';
+export * from './compiler/interpolation-config';
+export * from './compiler/lexer';
+export * from './compiler/parser';

--- a/src/angular-parse/angular/compiler/assertions.ts
+++ b/src/angular-parse/angular/compiler/assertions.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+import {isBlank, isPresent} from '../facade/lang';
+
+const isDevMode = () => false;
+
+export function assertArrayOfStrings(identifier: string, value: any) {
+    if (!isDevMode() || isBlank(value)) {
+        return;
+    }
+    if (!Array.isArray(value)) {
+        throw new Error(`Expected '${identifier}' to be an array of strings.`);
+    }
+    for (let i = 0; i < value.length; i += 1) {
+        if (typeof value[i] !== 'string') {
+            throw new Error(`Expected '${identifier}' to be an array of strings.`);
+        }
+    }
+}
+
+const INTERPOLATION_BLACKLIST_REGEXPS = [
+    /^\s*$/,        // empty
+    /[<>]/,         // html tag
+    /^[{}]$/,       // i18n expansion
+    /&(#|[a-z])/i,  // character reference,
+    /^\/\//,        // comment
+];
+
+export function assertInterpolationSymbols(identifier: string, value: any): void {
+    if (isPresent(value) && !(Array.isArray(value) && value.length == 2)) {
+        throw new Error(`Expected '${identifier}' to be an array, [start, end].`);
+    } else if (isDevMode() && !isBlank(value)) {
+        const start = value[0] as string;
+        const end = value[1] as string;
+        // black list checking
+        INTERPOLATION_BLACKLIST_REGEXPS.forEach(regexp => {
+            if (regexp.test(start) || regexp.test(end)) {
+                throw new Error(`['${start}', '${end}'] contains unusable interpolation symbol.`);
+            }
+        });
+    }
+}

--- a/src/angular-parse/angular/compiler/ast.ts
+++ b/src/angular-parse/angular/compiler/ast.ts
@@ -1,0 +1,393 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+import {isBlank} from '../facade/lang';
+
+export class ParserError {
+    public message: string;
+    constructor(
+        message: string, public input: string, public errLocation: string, public ctxLocation?: any) {
+        this.message = `Parser Error: ${message} ${errLocation} [${input}] in ${ctxLocation}`;
+    }
+}
+
+export class ParseSpan {
+    constructor(public start: number, public end: number) {}
+}
+
+export class AST {
+    constructor(public span: ParseSpan) {}
+    visit(visitor: AstVisitor, context: any = null): any { return null; }
+    toString(): string { return 'AST'; }
+}
+
+/**
+ * Represents a quoted expression of the form:
+ *
+ * quote = prefix `:` uninterpretedExpression
+ * prefix = identifier
+ * uninterpretedExpression = arbitrary string
+ *
+ * A quoted expression is meant to be pre-processed by an AST transformer that
+ * converts it into another AST that no longer contains quoted expressions.
+ * It is meant to allow third-party developers to extend Angular template
+ * expression language. The `uninterpretedExpression` part of the quote is
+ * therefore not interpreted by the Angular's own expression parser.
+ */
+export class Quote extends AST {
+    constructor(
+        span: ParseSpan, public prefix: string, public uninterpretedExpression: string,
+        public location: any) {
+        super(span);
+    }
+    visit(visitor: AstVisitor, context: any = null): any { return visitor.visitQuote(this, context); }
+    toString(): string { return 'Quote'; }
+}
+
+export class EmptyExpr extends AST {
+    visit(visitor: AstVisitor, context: any = null) {
+        // do nothing
+    }
+}
+
+export class ImplicitReceiver extends AST {
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitImplicitReceiver(this, context);
+    }
+}
+
+/**
+ * Multiple expressions separated by a semicolon.
+ */
+export class Chain extends AST {
+    constructor(span: ParseSpan, public expressions: any[]) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any { return visitor.visitChain(this, context); }
+}
+
+export class Conditional extends AST {
+    constructor(span: ParseSpan, public condition: AST, public trueExp: AST, public falseExp: AST) {
+        super(span);
+    }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitConditional(this, context);
+    }
+}
+
+export class PropertyRead extends AST {
+    constructor(span: ParseSpan, public receiver: AST, public name: string) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitPropertyRead(this, context);
+    }
+}
+
+export class PropertyWrite extends AST {
+    constructor(span: ParseSpan, public receiver: AST, public name: string, public value: AST) {
+        super(span);
+    }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitPropertyWrite(this, context);
+    }
+}
+
+export class SafePropertyRead extends AST {
+    constructor(span: ParseSpan, public receiver: AST, public name: string) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitSafePropertyRead(this, context);
+    }
+}
+
+export class KeyedRead extends AST {
+    constructor(span: ParseSpan, public obj: AST, public key: AST) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitKeyedRead(this, context);
+    }
+}
+
+export class KeyedWrite extends AST {
+    constructor(span: ParseSpan, public obj: AST, public key: AST, public value: AST) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitKeyedWrite(this, context);
+    }
+}
+
+export class BindingPipe extends AST {
+    constructor(span: ParseSpan, public exp: AST, public name: string, public args: any[]) {
+        super(span);
+    }
+    visit(visitor: AstVisitor, context: any = null): any { return visitor.visitPipe(this, context); }
+}
+
+export class LiteralPrimitive extends AST {
+    constructor(span: ParseSpan, public value: any) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitLiteralPrimitive(this, context);
+    }
+}
+
+export class LiteralArray extends AST {
+    constructor(span: ParseSpan, public expressions: any[]) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitLiteralArray(this, context);
+    }
+}
+
+export class LiteralMap extends AST {
+    constructor(span: ParseSpan, public keys: any[], public values: any[]) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitLiteralMap(this, context);
+    }
+}
+
+export class Interpolation extends AST {
+    constructor(span: ParseSpan, public strings: any[], public expressions: any[]) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitInterpolation(this, context);
+    }
+}
+
+export class Binary extends AST {
+    constructor(span: ParseSpan, public operation: string, public left: AST, public right: AST) {
+        super(span);
+    }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitBinary(this, context);
+    }
+}
+
+export class PrefixNot extends AST {
+    constructor(span: ParseSpan, public expression: AST) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitPrefixNot(this, context);
+    }
+}
+
+export class MethodCall extends AST {
+    constructor(span: ParseSpan, public receiver: AST, public name: string, public args: any[]) {
+        super(span);
+    }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitMethodCall(this, context);
+    }
+}
+
+export class SafeMethodCall extends AST {
+    constructor(span: ParseSpan, public receiver: AST, public name: string, public args: any[]) {
+        super(span);
+    }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitSafeMethodCall(this, context);
+    }
+}
+
+export class FunctionCall extends AST {
+    constructor(span: ParseSpan, public target: AST, public args: any[]) { super(span); }
+    visit(visitor: AstVisitor, context: any = null): any {
+        return visitor.visitFunctionCall(this, context);
+    }
+}
+
+export class ASTWithSource extends AST {
+    constructor(
+        public ast: AST, public source: string, public location: string,
+        public errors: ParserError[]) {
+        super(new ParseSpan(0, isBlank(source) ? 0 : source.length));
+    }
+    visit(visitor: AstVisitor, context: any = null): any { return this.ast.visit(visitor, context); }
+    toString(): string { return `${this.source} in ${this.location}`; }
+}
+
+export class TemplateBinding {
+    constructor(
+        public span: ParseSpan, public key: string, public keyIsVar: boolean, public name: string,
+        public expression: ASTWithSource) {}
+}
+
+export interface AstVisitor {
+    visitBinary(ast: Binary, context: any): any;
+    visitChain(ast: Chain, context: any): any;
+    visitConditional(ast: Conditional, context: any): any;
+    visitFunctionCall(ast: FunctionCall, context: any): any;
+    visitImplicitReceiver(ast: ImplicitReceiver, context: any): any;
+    visitInterpolation(ast: Interpolation, context: any): any;
+    visitKeyedRead(ast: KeyedRead, context: any): any;
+    visitKeyedWrite(ast: KeyedWrite, context: any): any;
+    visitLiteralArray(ast: LiteralArray, context: any): any;
+    visitLiteralMap(ast: LiteralMap, context: any): any;
+    visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any;
+    visitMethodCall(ast: MethodCall, context: any): any;
+    visitPipe(ast: BindingPipe, context: any): any;
+    visitPrefixNot(ast: PrefixNot, context: any): any;
+    visitPropertyRead(ast: PropertyRead, context: any): any;
+    visitPropertyWrite(ast: PropertyWrite, context: any): any;
+    visitQuote(ast: Quote, context: any): any;
+    visitSafeMethodCall(ast: SafeMethodCall, context: any): any;
+    visitSafePropertyRead(ast: SafePropertyRead, context: any): any;
+}
+
+export class RecursiveAstVisitor implements AstVisitor {
+    visitBinary(ast: Binary, context: any): any {
+        ast.left.visit(this);
+        ast.right.visit(this);
+        return null;
+    }
+    visitChain(ast: Chain, context: any): any { return this.visitAll(ast.expressions, context); }
+    visitConditional(ast: Conditional, context: any): any {
+        ast.condition.visit(this);
+        ast.trueExp.visit(this);
+        ast.falseExp.visit(this);
+        return null;
+    }
+    visitPipe(ast: BindingPipe, context: any): any {
+        ast.exp.visit(this);
+        this.visitAll(ast.args, context);
+        return null;
+    }
+    visitFunctionCall(ast: FunctionCall, context: any): any {
+        ast.target.visit(this);
+        this.visitAll(ast.args, context);
+        return null;
+    }
+    visitImplicitReceiver(ast: ImplicitReceiver, context: any): any { return null; }
+    visitInterpolation(ast: Interpolation, context: any): any {
+        return this.visitAll(ast.expressions, context);
+    }
+    visitKeyedRead(ast: KeyedRead, context: any): any {
+        ast.obj.visit(this);
+        ast.key.visit(this);
+        return null;
+    }
+    visitKeyedWrite(ast: KeyedWrite, context: any): any {
+        ast.obj.visit(this);
+        ast.key.visit(this);
+        ast.value.visit(this);
+        return null;
+    }
+    visitLiteralArray(ast: LiteralArray, context: any): any {
+        return this.visitAll(ast.expressions, context);
+    }
+    visitLiteralMap(ast: LiteralMap, context: any): any { return this.visitAll(ast.values, context); }
+    visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any { return null; }
+    visitMethodCall(ast: MethodCall, context: any): any {
+        ast.receiver.visit(this);
+        return this.visitAll(ast.args, context);
+    }
+    visitPrefixNot(ast: PrefixNot, context: any): any {
+        ast.expression.visit(this);
+        return null;
+    }
+    visitPropertyRead(ast: PropertyRead, context: any): any {
+        ast.receiver.visit(this);
+        return null;
+    }
+    visitPropertyWrite(ast: PropertyWrite, context: any): any {
+        ast.receiver.visit(this);
+        ast.value.visit(this);
+        return null;
+    }
+    visitSafePropertyRead(ast: SafePropertyRead, context: any): any {
+        ast.receiver.visit(this);
+        return null;
+    }
+    visitSafeMethodCall(ast: SafeMethodCall, context: any): any {
+        ast.receiver.visit(this);
+        return this.visitAll(ast.args, context);
+    }
+    visitAll(asts: AST[], context: any): any {
+        asts.forEach(ast => ast.visit(this, context));
+        return null;
+    }
+    visitQuote(ast: Quote, context: any): any { return null; }
+}
+
+export class AstTransformer implements AstVisitor {
+    visitImplicitReceiver(ast: ImplicitReceiver, context: any): AST { return ast; }
+
+    visitInterpolation(ast: Interpolation, context: any): AST {
+        return new Interpolation(ast.span, ast.strings, this.visitAll(ast.expressions));
+    }
+
+    visitLiteralPrimitive(ast: LiteralPrimitive, context: any): AST {
+        return new LiteralPrimitive(ast.span, ast.value);
+    }
+
+    visitPropertyRead(ast: PropertyRead, context: any): AST {
+        return new PropertyRead(ast.span, ast.receiver.visit(this), ast.name);
+    }
+
+    visitPropertyWrite(ast: PropertyWrite, context: any): AST {
+        return new PropertyWrite(ast.span, ast.receiver.visit(this), ast.name, ast.value);
+    }
+
+    visitSafePropertyRead(ast: SafePropertyRead, context: any): AST {
+        return new SafePropertyRead(ast.span, ast.receiver.visit(this), ast.name);
+    }
+
+    visitMethodCall(ast: MethodCall, context: any): AST {
+        return new MethodCall(ast.span, ast.receiver.visit(this), ast.name, this.visitAll(ast.args));
+    }
+
+    visitSafeMethodCall(ast: SafeMethodCall, context: any): AST {
+        return new SafeMethodCall(
+            ast.span, ast.receiver.visit(this), ast.name, this.visitAll(ast.args));
+    }
+
+    visitFunctionCall(ast: FunctionCall, context: any): AST {
+        return new FunctionCall(ast.span, ast.target.visit(this), this.visitAll(ast.args));
+    }
+
+    visitLiteralArray(ast: LiteralArray, context: any): AST {
+        return new LiteralArray(ast.span, this.visitAll(ast.expressions));
+    }
+
+    visitLiteralMap(ast: LiteralMap, context: any): AST {
+        return new LiteralMap(ast.span, ast.keys, this.visitAll(ast.values));
+    }
+
+    visitBinary(ast: Binary, context: any): AST {
+        return new Binary(ast.span, ast.operation, ast.left.visit(this), ast.right.visit(this));
+    }
+
+    visitPrefixNot(ast: PrefixNot, context: any): AST {
+        return new PrefixNot(ast.span, ast.expression.visit(this));
+    }
+
+    visitConditional(ast: Conditional, context: any): AST {
+        return new Conditional(
+            ast.span, ast.condition.visit(this), ast.trueExp.visit(this), ast.falseExp.visit(this));
+    }
+
+    visitPipe(ast: BindingPipe, context: any): AST {
+        return new BindingPipe(ast.span, ast.exp.visit(this), ast.name, this.visitAll(ast.args));
+    }
+
+    visitKeyedRead(ast: KeyedRead, context: any): AST {
+        return new KeyedRead(ast.span, ast.obj.visit(this), ast.key.visit(this));
+    }
+
+    visitKeyedWrite(ast: KeyedWrite, context: any): AST {
+        return new KeyedWrite(
+            ast.span, ast.obj.visit(this), ast.key.visit(this), ast.value.visit(this));
+    }
+
+    visitAll(asts: any[]): any[] {
+        const res = new Array(asts.length);
+        for (let i = 0; i < asts.length; ++i) {
+            res[i] = asts[i].visit(this);
+        }
+        return res;
+    }
+
+    visitChain(ast: Chain, context: any): AST {
+        return new Chain(ast.span, this.visitAll(ast.expressions));
+    }
+
+    visitQuote(ast: Quote, context: any): AST {
+        return new Quote(ast.span, ast.prefix, ast.uninterpretedExpression, ast.location);
+    }
+}

--- a/src/angular-parse/angular/compiler/chars.ts
+++ b/src/angular-parse/angular/compiler/chars.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export const $EOF = 0;
+export const $TAB = 9;
+export const $LF = 10;
+export const $VTAB = 11;
+export const $FF = 12;
+export const $CR = 13;
+export const $SPACE = 32;
+export const $BANG = 33;
+export const $DQ = 34;
+export const $HASH = 35;
+export const $$ = 36;
+export const $PERCENT = 37;
+export const $AMPERSAND = 38;
+export const $SQ = 39;
+export const $LPAREN = 40;
+export const $RPAREN = 41;
+export const $STAR = 42;
+export const $PLUS = 43;
+export const $COMMA = 44;
+export const $MINUS = 45;
+export const $PERIOD = 46;
+export const $SLASH = 47;
+export const $COLON = 58;
+export const $SEMICOLON = 59;
+export const $LT = 60;
+export const $EQ = 61;
+export const $GT = 62;
+export const $QUESTION = 63;
+
+export const $0 = 48;
+export const $9 = 57;
+
+export const $A = 65;
+export const $E = 69;
+export const $F = 70;
+export const $X = 88;
+export const $Z = 90;
+
+export const $LBRACKET = 91;
+export const $BACKSLASH = 92;
+export const $RBRACKET = 93;
+export const $CARET = 94;
+export const $_ = 95;
+
+export const $a = 97;
+export const $e = 101;
+export const $f = 102;
+export const $n = 110;
+export const $r = 114;
+export const $t = 116;
+export const $u = 117;
+export const $v = 118;
+export const $x = 120;
+export const $z = 122;
+
+export const $LBRACE = 123;
+export const $BAR = 124;
+export const $RBRACE = 125;
+export const $NBSP = 160;
+
+export const $PIPE = 124;
+export const $TILDA = 126;
+export const $AT = 64;
+
+export const $BT = 96;
+
+export function isWhitespace(code: number): boolean {
+    return (code >= $TAB && code <= $SPACE) || (code == $NBSP);
+}
+
+export function isDigit(code: number): boolean {
+    return $0 <= code && code <= $9;
+}
+
+export function isAsciiLetter(code: number): boolean {
+    return code >= $a && code <= $z || code >= $A && code <= $Z;
+}
+
+export function isAsciiHexDigit(code: number): boolean {
+    return code >= $a && code <= $f || code >= $A && code <= $F || isDigit(code);
+}

--- a/src/angular-parse/angular/compiler/interpolation-config.ts
+++ b/src/angular-parse/angular/compiler/interpolation-config.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/* tslint:disable:no-use-before-declare */
+
+import { assertInterpolationSymbols } from './assertions';
+
+export class InterpolationConfig {
+    static fromArray(markers: [string, string]): InterpolationConfig {
+        if (!markers) {
+            return DEFAULT_INTERPOLATION_CONFIG;
+        }
+
+        assertInterpolationSymbols('interpolation', markers);
+        return new InterpolationConfig(markers[0], markers[1]);
+    }
+
+    constructor(public start: string, public end: string) { };
+}
+
+export const DEFAULT_INTERPOLATION_CONFIG: InterpolationConfig =
+    new InterpolationConfig('{{', '}}');

--- a/src/angular-parse/angular/compiler/lexer.ts
+++ b/src/angular-parse/angular/compiler/lexer.ts
@@ -1,0 +1,387 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+ /* tslint:disable:no-use-before-declare */
+
+
+import * as chars from './chars';
+import {NumberWrapper} from '../facade/lang';
+
+export enum TokenType {
+    Character,
+    Identifier,
+    Keyword,
+    String,
+    Operator,
+    Number,
+    Error
+}
+
+const KEYWORDS = ['var', 'let', 'null', 'undefined', 'true', 'false', 'if', 'else', 'this'];
+
+export class Lexer {
+    tokenize(text: string): Token[] {
+        const scanner = new _Scanner(text);
+        const tokens: Token[] = [];
+        let token = scanner.scanToken();
+        while (token != null) {
+            tokens.push(token);
+            token = scanner.scanToken();
+        }
+        return tokens;
+    }
+}
+
+export class Token {
+    constructor(
+        public index: number, public type: TokenType, public numValue: number,
+        public strValue: string) {}
+
+    isCharacter(code: number): boolean {
+        return this.type == TokenType.Character && this.numValue == code;
+    }
+
+    isNumber(): boolean { return this.type == TokenType.Number; }
+
+    isString(): boolean { return this.type == TokenType.String; }
+
+    isOperator(operater: string): boolean {
+        return this.type == TokenType.Operator && this.strValue == operater;
+    }
+
+    isIdentifier(): boolean { return this.type == TokenType.Identifier; }
+
+    isKeyword(): boolean { return this.type == TokenType.Keyword; }
+
+    isKeywordLet(): boolean { return this.type == TokenType.Keyword && this.strValue == 'let'; }
+
+    isKeywordNull(): boolean { return this.type == TokenType.Keyword && this.strValue == 'null'; }
+
+    isKeywordUndefined(): boolean {
+        return this.type == TokenType.Keyword && this.strValue == 'undefined';
+    }
+
+    isKeywordTrue(): boolean { return this.type == TokenType.Keyword && this.strValue == 'true'; }
+
+    isKeywordFalse(): boolean { return this.type == TokenType.Keyword && this.strValue == 'false'; }
+
+    isKeywordThis(): boolean { return this.type == TokenType.Keyword && this.strValue == 'this'; }
+
+    isError(): boolean { return this.type == TokenType.Error; }
+
+    toNumber(): number { return this.type == TokenType.Number ? this.numValue : -1; }
+
+    toString(): string {
+        switch (this.type) {
+            case TokenType.Character:
+            case TokenType.Identifier:
+            case TokenType.Keyword:
+            case TokenType.Operator:
+            case TokenType.String:
+            case TokenType.Error:
+                return this.strValue;
+            case TokenType.Number:
+                return this.numValue.toString();
+            default:
+                return null;
+        }
+    }
+}
+
+function newCharacterToken(index: number, code: number): Token {
+    return new Token(index, TokenType.Character, code, String.fromCharCode(code));
+}
+
+function newIdentifierToken(index: number, text: string): Token {
+    return new Token(index, TokenType.Identifier, 0, text);
+}
+
+function newKeywordToken(index: number, text: string): Token {
+    return new Token(index, TokenType.Keyword, 0, text);
+}
+
+function newOperatorToken(index: number, text: string): Token {
+    return new Token(index, TokenType.Operator, 0, text);
+}
+
+function newStringToken(index: number, text: string): Token {
+    return new Token(index, TokenType.String, 0, text);
+}
+
+function newNumberToken(index: number, n: number): Token {
+    return new Token(index, TokenType.Number, n, '');
+}
+
+function newErrorToken(index: number, message: string): Token {
+    return new Token(index, TokenType.Error, 0, message);
+}
+
+export const EOF: Token = new Token(-1, TokenType.Character, 0, '');
+
+// tslint:disable-next-line:class-name
+class _Scanner {
+    length: number;
+    peek = 0;
+    index = -1;
+
+    constructor(public input: string) {
+        this.length = input.length;
+        this.advance();
+    }
+
+    advance() {
+        this.peek = ++this.index >= this.length ? chars.$EOF : this.input.charCodeAt(this.index);
+    }
+
+    scanToken(): Token {
+        const input = this.input, length = this.length;
+        let peek = this.peek, index = this.index;
+
+        // Skip whitespace.
+        while (peek <= chars.$SPACE) {
+            if (++index >= length) {
+                peek = chars.$EOF;
+                break;
+            } else {
+                peek = input.charCodeAt(index);
+            }
+        }
+
+        this.peek = peek;
+        this.index = index;
+
+        if (index >= length) {
+            return null;
+        }
+
+        // Handle identifiers and numbers.
+        if (isIdentifierStart(peek)) return this.scanIdentifier();
+        if (chars.isDigit(peek)) return this.scanNumber(index);
+
+        const start: number = index;
+        switch (peek) {
+            case chars.$PERIOD:
+                this.advance();
+                return chars.isDigit(this.peek) ? this.scanNumber(start) :
+                    newCharacterToken(start, chars.$PERIOD);
+            case chars.$LPAREN:
+            case chars.$RPAREN:
+            case chars.$LBRACE:
+            case chars.$RBRACE:
+            case chars.$LBRACKET:
+            case chars.$RBRACKET:
+            case chars.$COMMA:
+            case chars.$COLON:
+            case chars.$SEMICOLON:
+                return this.scanCharacter(start, peek);
+            case chars.$SQ:
+            case chars.$DQ:
+                return this.scanString();
+            case chars.$HASH:
+            case chars.$PLUS:
+            case chars.$MINUS:
+            case chars.$STAR:
+            case chars.$SLASH:
+            case chars.$PERCENT:
+            case chars.$CARET:
+                return this.scanOperator(start, String.fromCharCode(peek));
+            case chars.$QUESTION:
+                return this.scanComplexOperator(start, '?', chars.$PERIOD, '.');
+            case chars.$LT:
+            case chars.$GT:
+                return this.scanComplexOperator(start, String.fromCharCode(peek), chars.$EQ, '=');
+            case chars.$BANG:
+            case chars.$EQ:
+                return this.scanComplexOperator(
+                    start, String.fromCharCode(peek), chars.$EQ, '=', chars.$EQ, '=');
+            case chars.$AMPERSAND:
+                return this.scanComplexOperator(start, '&', chars.$AMPERSAND, '&');
+            case chars.$BAR:
+                return this.scanComplexOperator(start, '|', chars.$BAR, '|');
+            case chars.$NBSP:
+                while (chars.isWhitespace(this.peek)) this.advance();
+                return this.scanToken();
+        }
+
+        this.advance();
+        return this.error(`Unexpected character [${String.fromCharCode(peek)}]`, 0);
+    }
+
+    scanCharacter(start: number, code: number): Token {
+        this.advance();
+        return newCharacterToken(start, code);
+    }
+
+
+    scanOperator(start: number, str: string): Token {
+        this.advance();
+        return newOperatorToken(start, str);
+    }
+
+    /**
+     * Tokenize a 2/3 char long operator
+     *
+     * @param start start index in the expression
+     * @param one first symbol (always part of the operator)
+     * @param twoCode code point for the second symbol
+     * @param two second symbol (part of the operator when the second code point matches)
+     * @param threeCode code point for the third symbol
+     * @param three third symbol (part of the operator when provided and matches source expression)
+     * @returns {Token}
+     */
+    scanComplexOperator(
+        start: number, one: string, twoCode: number, two: string, threeCode?: number,
+        three?: string): Token {
+        this.advance();
+        let str: string = one;
+        if (this.peek == twoCode) {
+            this.advance();
+            str += two;
+        }
+        if (threeCode != null && this.peek == threeCode) {
+            this.advance();
+            str += three;
+        }
+        return newOperatorToken(start, str);
+    }
+
+    scanIdentifier(): Token {
+        const start: number = this.index;
+        this.advance();
+        while (isIdentifierPart(this.peek)) this.advance();
+        const str: string = this.input.substring(start, this.index);
+        return KEYWORDS.indexOf(str) > -1 ? newKeywordToken(start, str) :
+            newIdentifierToken(start, str);
+    }
+
+    scanNumber(start: number): Token {
+        let simple: boolean = (this.index === start);
+        this.advance();  // Skip initial digit.
+        while (true) {
+            if (chars.isDigit(this.peek)) {
+                // Do nothing.
+            } else if (this.peek == chars.$PERIOD) {
+                simple = false;
+            } else if (isExponentStart(this.peek)) {
+                this.advance();
+                if (isExponentSign(this.peek)) this.advance();
+                if (!chars.isDigit(this.peek)) return this.error('Invalid exponent', -1);
+                simple = false;
+            } else {
+                break;
+            }
+            this.advance();
+        }
+        const str: string = this.input.substring(start, this.index);
+        const value: number = simple ? NumberWrapper.parseIntAutoRadix(str) : parseFloat(str);
+        return newNumberToken(start, value);
+    }
+
+    scanString(): Token {
+        const start: number = this.index;
+        const quote: number = this.peek;
+        this.advance();  // Skip initial quote.
+
+        let buffer = '';
+        let marker: number = this.index;
+        const input: string = this.input;
+
+        while (this.peek != quote) {
+            if (this.peek == chars.$BACKSLASH) {
+                buffer += input.substring(marker, this.index);
+                this.advance();
+                let unescapedCode: number;
+                // Workaround for TS2.1-introduced type strictness
+                this.peek = this.peek;
+                if (this.peek == chars.$u) {
+                    // 4 character hex code for unicode character.
+                    const hex: string = input.substring(this.index + 1, this.index + 5);
+                    if (/^[0-9a-f]+$/i.test(hex)) {
+                        unescapedCode = parseInt(hex, 16);
+                    } else {
+                        return this.error(`Invalid unicode escape [\\u${hex}]`, 0);
+                    }
+                    for (let i = 0; i < 5; i++) {
+                        this.advance();
+                    }
+                } else {
+                    unescapedCode = unescape(this.peek);
+                    this.advance();
+                }
+                buffer += String.fromCharCode(unescapedCode);
+                marker = this.index;
+            } else if (this.peek == chars.$EOF) {
+                return this.error('Unterminated quote', 0);
+            } else {
+                this.advance();
+            }
+        }
+
+        const last: string = input.substring(marker, this.index);
+        this.advance();  // Skip terminating quote.
+
+        return newStringToken(start, buffer + last);
+    }
+
+    error(message: string, offset: number): Token {
+        const position: number = this.index + offset;
+        return newErrorToken(
+            position, `Lexer Error: ${message} at column ${position} in expression [${this.input}]`);
+    }
+}
+
+function isIdentifierStart(code: number): boolean {
+    return (chars.$a <= code && code <= chars.$z) || (chars.$A <= code && code <= chars.$Z) ||
+        (code == chars.$_) || (code == chars.$$);
+}
+
+export function isIdentifier(input: string): boolean {
+    if (input.length == 0) return false;
+    const scanner = new _Scanner(input);
+    if (!isIdentifierStart(scanner.peek)) return false;
+    scanner.advance();
+    while (scanner.peek !== chars.$EOF) {
+        if (!isIdentifierPart(scanner.peek)) return false;
+        scanner.advance();
+    }
+    return true;
+}
+
+function isIdentifierPart(code: number): boolean {
+    return chars.isAsciiLetter(code) || chars.isDigit(code) || (code == chars.$_) ||
+        (code == chars.$$);
+}
+
+function isExponentStart(code: number): boolean {
+    return code == chars.$e || code == chars.$E;
+}
+
+function isExponentSign(code: number): boolean {
+    return code == chars.$MINUS || code == chars.$PLUS;
+}
+
+export function isQuote(code: number): boolean {
+    return code === chars.$SQ || code === chars.$DQ || code === chars.$BT;
+}
+
+function unescape(code: number): number {
+    switch (code) {
+        case chars.$n:
+            return chars.$LF;
+        case chars.$f:
+            return chars.$FF;
+        case chars.$r:
+            return chars.$CR;
+        case chars.$t:
+            return chars.$TAB;
+        case chars.$v:
+            return chars.$VTAB;
+        default:
+            return code;
+    }
+}

--- a/src/angular-parse/angular/compiler/parser.ts
+++ b/src/angular-parse/angular/compiler/parser.ts
@@ -1,0 +1,821 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/* tslint:disable:no-use-before-declare */
+
+
+import * as chars from './chars';
+import { escapeRegExp, isBlank, isPresent } from '../facade/lang';
+import { DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig } from './interpolation-config';
+
+import {
+    AST, ASTWithSource, AstVisitor, Binary, BindingPipe, Chain, Conditional, EmptyExpr,
+    FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray,
+    LiteralMap, LiteralPrimitive, MethodCall, ParseSpan, ParserError, PrefixNot, PropertyRead,
+    PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, TemplateBinding
+} from './ast';
+import { EOF, Lexer, Token, TokenType, isIdentifier, isQuote } from './lexer';
+
+
+export class SplitInterpolation {
+    constructor(public strings: string[], public expressions: string[], public offsets: number[]) { }
+}
+
+export class TemplateBindingParseResult {
+    constructor(
+        public templateBindings: TemplateBinding[], public warnings: string[],
+        public errors: ParserError[]) { }
+}
+
+function _createInterpolateRegExp(config: InterpolationConfig): RegExp {
+    const pattern = escapeRegExp(config.start) + '([\\s\\S]*?)' + escapeRegExp(config.end);
+    return new RegExp(pattern, 'g');
+}
+
+export class Parser {
+    private errors: ParserError[] = [];
+
+    constructor(private _lexer: Lexer) { }
+
+    parseAction(
+        input: string, location: any,
+        interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): ASTWithSource {
+        this._checkNoInterpolation(input, location, interpolationConfig);
+        const sourceToLex = this._stripComments(input);
+        const tokens = this._lexer.tokenize(this._stripComments(input));
+        const ast = new _ParseAST(
+            input, location, tokens, sourceToLex.length, true, this.errors,
+            input.length - sourceToLex.length)
+            .parseChain();
+        return new ASTWithSource(ast, input, location, this.errors);
+    }
+
+    parseBinding(
+        input: string, location: any,
+        interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): ASTWithSource {
+        const ast = this._parseBindingAst(input, location, interpolationConfig);
+        return new ASTWithSource(ast, input, location, this.errors);
+    }
+
+    parseSimpleBinding(
+        input: string, location: string,
+        interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): ASTWithSource {
+        const ast = this._parseBindingAst(input, location, interpolationConfig);
+        const errors = SimpleExpressionChecker.check(ast);
+        if (errors.length > 0) {
+            this._reportError(
+                `Host binding expression cannot contain ${errors.join(' ')}`, input, location);
+        }
+        return new ASTWithSource(ast, input, location, this.errors);
+    }
+
+    private _reportError(message: string, input: string, errLocation: string, ctxLocation?: any) {
+        this.errors.push(new ParserError(message, input, errLocation, ctxLocation));
+    }
+
+    private _parseBindingAst(
+        input: string, location: string, interpolationConfig: InterpolationConfig): AST {
+        // Quotes expressions use 3rd-party expression language. We don't want to use
+        // our lexer or parser for that, so we check for that ahead of time.
+        const quote = this._parseQuote(input, location);
+
+        if (isPresent(quote)) {
+            return quote;
+        }
+
+        this._checkNoInterpolation(input, location, interpolationConfig);
+        const sourceToLex = this._stripComments(input);
+        const tokens = this._lexer.tokenize(sourceToLex);
+        return new _ParseAST(
+            input, location, tokens, sourceToLex.length, false, this.errors,
+            input.length - sourceToLex.length)
+            .parseChain();
+    }
+
+    private _parseQuote(input: string, location: any): AST {
+        if (isBlank(input)) return null;
+        const prefixSeparatorIndex = input.indexOf(':');
+        if (prefixSeparatorIndex == -1) return null;
+        const prefix = input.substring(0, prefixSeparatorIndex).trim();
+        if (!isIdentifier(prefix)) return null;
+        const uninterpretedExpression = input.substring(prefixSeparatorIndex + 1);
+        return new Quote(new ParseSpan(0, input.length), prefix, uninterpretedExpression, location);
+    }
+
+    parseTemplateBindings(prefixToken: string, input: string, location: any):
+        TemplateBindingParseResult {
+        const tokens = this._lexer.tokenize(input);
+        if (prefixToken) {
+            // Prefix the tokens with the tokens from prefixToken but have them take no space (0 index).
+            const prefixTokens = this._lexer.tokenize(prefixToken).map(t => {
+                t.index = 0;
+                return t;
+            });
+            tokens.unshift(...prefixTokens);
+        }
+        return new _ParseAST(input, location, tokens, input.length, false, this.errors, 0)
+            .parseTemplateBindings();
+    }
+
+    parseInterpolation(
+        input: string, location: any,
+        interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): ASTWithSource {
+        const split = this.splitInterpolation(input, location, interpolationConfig);
+        if (split == null) return null;
+
+        const expressions: AST[] = [];
+
+        for (let i = 0; i < split.expressions.length; ++i) {
+            const expressionText = split.expressions[i];
+            const sourceToLex = this._stripComments(expressionText);
+            const tokens = this._lexer.tokenize(this._stripComments(split.expressions[i]));
+            const ast = new _ParseAST(
+                input, location, tokens, sourceToLex.length, false, this.errors,
+                split.offsets[i] + (expressionText.length - sourceToLex.length))
+                .parseChain();
+            expressions.push(ast);
+        }
+
+        return new ASTWithSource(
+            new Interpolation(
+                new ParseSpan(0, isBlank(input) ? 0 : input.length), split.strings, expressions),
+            input, location, this.errors);
+    }
+
+    splitInterpolation(
+        input: string, location: string,
+        interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): SplitInterpolation {
+        const regexp = _createInterpolateRegExp(interpolationConfig);
+        const parts = input.split(regexp);
+        if (parts.length <= 1) {
+            return null;
+        }
+        const strings: string[] = [];
+        const expressions: string[] = [];
+        const offsets: number[] = [];
+        let offset = 0;
+        for (let i = 0; i < parts.length; i++) {
+            const part: string = parts[i];
+            if (i % 2 === 0) {
+                // fixed string
+                strings.push(part);
+                offset += part.length;
+            } else if (part.trim().length > 0) {
+                offset += interpolationConfig.start.length;
+                expressions.push(part);
+                offsets.push(offset);
+                offset += part.length + interpolationConfig.end.length;
+            } else {
+                this._reportError(
+                    'Blank expressions are not allowed in interpolated strings', input,
+                    `at column ${this._findInterpolationErrorColumn(parts, i, interpolationConfig)} in`,
+                    location);
+                expressions.push('$implict');
+                offsets.push(offset);
+            }
+        }
+        return new SplitInterpolation(strings, expressions, offsets);
+    }
+
+    wrapLiteralPrimitive(input: string, location: any): ASTWithSource {
+        return new ASTWithSource(
+            new LiteralPrimitive(new ParseSpan(0, isBlank(input) ? 0 : input.length), input), input,
+            location, this.errors);
+    }
+
+    private _stripComments(input: string): string {
+        const i = this._commentStart(input);
+        return isPresent(i) ? input.substring(0, i).trim() : input;
+    }
+
+    private _commentStart(input: string): number {
+        let outerQuote: number = null;
+        for (let i = 0; i < input.length - 1; i++) {
+            const char = input.charCodeAt(i);
+            const nextChar = input.charCodeAt(i + 1);
+
+            if (char === chars.$SLASH && nextChar == chars.$SLASH && isBlank(outerQuote)) return i;
+
+            if (outerQuote === char) {
+                outerQuote = null;
+            } else if (isBlank(outerQuote) && isQuote(char)) {
+                outerQuote = char;
+            }
+        }
+        return null;
+    }
+
+    private _checkNoInterpolation(
+        input: string, location: any, interpolationConfig: InterpolationConfig): void {
+        const regexp = _createInterpolateRegExp(interpolationConfig);
+        const parts = input.split(regexp);
+        if (parts.length > 1) {
+            this._reportError(
+                `Got interpolation (${interpolationConfig.start}${interpolationConfig.end}) where expression was expected`,
+                input,
+                `at column ${this._findInterpolationErrorColumn(parts, 1, interpolationConfig)} in`,
+                location);
+        }
+    }
+
+    private _findInterpolationErrorColumn(
+        parts: string[], partInErrIdx: number, interpolationConfig: InterpolationConfig): number {
+        let errLocation = '';
+        for (let j = 0; j < partInErrIdx; j++) {
+            errLocation += j % 2 === 0 ?
+                parts[j] :
+                `${interpolationConfig.start}${parts[j]}${interpolationConfig.end}`;
+        }
+
+        return errLocation.length;
+    }
+}
+
+// tslint:disable-next-line:class-name
+export class _ParseAST {
+    private rparensExpected = 0;
+    private rbracketsExpected = 0;
+    private rbracesExpected = 0;
+
+    index = 0;
+
+    constructor(
+        public input: string, public location: any, public tokens: Token[],
+        public inputLength: number, public parseAction: boolean, private errors: ParserError[],
+        private offset: number) { }
+
+    peek(offset: number): Token {
+        const i = this.index + offset;
+        return i < this.tokens.length ? this.tokens[i] : EOF;
+    }
+
+    get next(): Token { return this.peek(0); }
+
+    get inputIndex(): number {
+        return (this.index < this.tokens.length) ? this.next.index + this.offset :
+            this.inputLength + this.offset;
+    }
+
+    span(start: number) { return new ParseSpan(start, this.inputIndex); }
+
+    advance() { this.index++; }
+
+    optionalCharacter(code: number): boolean {
+        if (this.next.isCharacter(code)) {
+            this.advance();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    peekKeywordLet(): boolean { return this.next.isKeywordLet(); }
+
+    expectCharacter(code: number) {
+        if (this.optionalCharacter(code)) return;
+        this.error(`Missing expected ${String.fromCharCode(code)}`);
+    }
+
+    optionalOperator(op: string): boolean {
+        if (this.next.isOperator(op)) {
+            this.advance();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    expectOperator(operator: string) {
+        if (this.optionalOperator(operator)) return;
+        this.error(`Missing expected operator ${operator}`);
+    }
+
+    expectIdentifierOrKeyword(): string {
+        const n = this.next;
+        if (!n.isIdentifier() && !n.isKeyword()) {
+            this.error(`Unexpected token ${n}, expected identifier or keyword`);
+            return '';
+        }
+        this.advance();
+        return n.toString();
+    }
+
+    expectIdentifierOrKeywordOrString(): string {
+        const n = this.next;
+        if (!n.isIdentifier() && !n.isKeyword() && !n.isString()) {
+            this.error(`Unexpected token ${n}, expected identifier, keyword, or string`);
+            return '';
+        }
+        this.advance();
+        return n.toString();
+    }
+
+    parseChain(): AST {
+        const exprs: AST[] = [];
+        const start = this.inputIndex;
+        while (this.index < this.tokens.length) {
+            const expr = this.parsePipe();
+            exprs.push(expr);
+
+            if (this.optionalCharacter(chars.$SEMICOLON)) {
+                if (!this.parseAction) {
+                    this.error('Binding expression cannot contain chained expression');
+                }
+                while (this.optionalCharacter(chars.$SEMICOLON)) {
+                }  // read all semicolons
+            } else if (this.index < this.tokens.length) {
+                this.error(`Unexpected token '${this.next}'`);
+            }
+        }
+        if (exprs.length == 0) return new EmptyExpr(this.span(start));
+        if (exprs.length == 1) return exprs[0];
+        return new Chain(this.span(start), exprs);
+    }
+
+    parsePipe(): AST {
+        let result = this.parseExpression();
+        if (this.optionalOperator('|')) {
+            if (this.parseAction) {
+                this.error('Cannot have a pipe in an action expression');
+            }
+
+            do {
+                const name = this.expectIdentifierOrKeyword();
+                const args: AST[] = [];
+                while (this.optionalCharacter(chars.$COLON)) {
+                    args.push(this.parseExpression());
+                }
+                result = new BindingPipe(this.span(result.span.start), result, name, args);
+            } while (this.optionalOperator('|'));
+        }
+
+        return result;
+    }
+
+    parseExpression(): AST { return this.parseConditional(); }
+
+    parseConditional(): AST {
+        const start = this.inputIndex;
+        const result = this.parseLogicalOr();
+
+        if (this.optionalOperator('?')) {
+            const yes = this.parsePipe();
+            let no: AST;
+            if (!this.optionalCharacter(chars.$COLON)) {
+                const end = this.inputIndex;
+                const expression = this.input.substring(start, end);
+                this.error(`Conditional expression ${expression} requires all 3 expressions`);
+                no = new EmptyExpr(this.span(start));
+            } else {
+                no = this.parsePipe();
+            }
+            return new Conditional(this.span(start), result, yes, no);
+        } else {
+            return result;
+        }
+    }
+
+    parseLogicalOr(): AST {
+        // '||'
+        let result = this.parseLogicalAnd();
+        while (this.optionalOperator('||')) {
+            const right = this.parseLogicalAnd();
+            result = new Binary(this.span(result.span.start), '||', result, right);
+        }
+        return result;
+    }
+
+    parseLogicalAnd(): AST {
+        // '&&'
+        let result = this.parseEquality();
+        while (this.optionalOperator('&&')) {
+            const right = this.parseEquality();
+            result = new Binary(this.span(result.span.start), '&&', result, right);
+        }
+        return result;
+    }
+
+    parseEquality(): AST {
+        // '==','!=','===','!=='
+        let result = this.parseRelational();
+        while (this.next.type == TokenType.Operator) {
+            const operator = this.next.strValue;
+            switch (operator) {
+                case '==':
+                case '===':
+                case '!=':
+                case '!==':
+                    this.advance();
+                    const right = this.parseRelational();
+                    result = new Binary(this.span(result.span.start), operator, result, right);
+                    continue;
+            }
+            break;
+        }
+        return result;
+    }
+
+    parseRelational(): AST {
+        // '<', '>', '<=', '>='
+        let result = this.parseAdditive();
+        while (this.next.type == TokenType.Operator) {
+            const operator = this.next.strValue;
+            switch (operator) {
+                case '<':
+                case '>':
+                case '<=':
+                case '>=':
+                    this.advance();
+                    const right = this.parseAdditive();
+                    result = new Binary(this.span(result.span.start), operator, result, right);
+                    continue;
+            }
+            break;
+        }
+        return result;
+    }
+
+    parseAdditive(): AST {
+        // '+', '-'
+        let result = this.parseMultiplicative();
+        while (this.next.type == TokenType.Operator) {
+            const operator = this.next.strValue;
+            switch (operator) {
+                case '+':
+                case '-':
+                    this.advance();
+                    const right = this.parseMultiplicative();
+                    result = new Binary(this.span(result.span.start), operator, result, right);
+                    continue;
+            }
+            break;
+        }
+        return result;
+    }
+
+    parseMultiplicative(): AST {
+        // '*', '%', '/'
+        let result = this.parsePrefix();
+        while (this.next.type == TokenType.Operator) {
+            const operator = this.next.strValue;
+            switch (operator) {
+                case '*':
+                case '%':
+                case '/':
+                    this.advance();
+                    const right = this.parsePrefix();
+                    result = new Binary(this.span(result.span.start), operator, result, right);
+                    continue;
+            }
+            break;
+        }
+        return result;
+    }
+
+    parsePrefix(): AST {
+        if (this.next.type == TokenType.Operator) {
+            const start = this.inputIndex;
+            const operator = this.next.strValue;
+            let result: AST;
+            switch (operator) {
+                case '+':
+                    this.advance();
+                    return this.parsePrefix();
+                case '-':
+                    this.advance();
+                    result = this.parsePrefix();
+                    return new Binary(
+                        this.span(start), operator, new LiteralPrimitive(new ParseSpan(start, start), 0),
+                        result);
+                case '!':
+                    this.advance();
+                    result = this.parsePrefix();
+                    return new PrefixNot(this.span(start), result);
+            }
+        }
+        return this.parseCallChain();
+    }
+
+    parseCallChain(): AST {
+        let result = this.parsePrimary();
+        while (true) {
+            if (this.optionalCharacter(chars.$PERIOD)) {
+                result = this.parseAccessMemberOrMethodCall(result, false);
+
+            } else if (this.optionalOperator('?.')) {
+                result = this.parseAccessMemberOrMethodCall(result, true);
+
+            } else if (this.optionalCharacter(chars.$LBRACKET)) {
+                this.rbracketsExpected++;
+                const key = this.parsePipe();
+                this.rbracketsExpected--;
+                this.expectCharacter(chars.$RBRACKET);
+                if (this.optionalOperator('=')) {
+                    const value = this.parseConditional();
+                    result = new KeyedWrite(this.span(result.span.start), result, key, value);
+                } else {
+                    result = new KeyedRead(this.span(result.span.start), result, key);
+                }
+
+            } else if (this.optionalCharacter(chars.$LPAREN)) {
+                this.rparensExpected++;
+                const args = this.parseCallArguments();
+                this.rparensExpected--;
+                this.expectCharacter(chars.$RPAREN);
+                result = new FunctionCall(this.span(result.span.start), result, args);
+
+            } else {
+                return result;
+            }
+        }
+    }
+
+    parsePrimary(): AST {
+        const start = this.inputIndex;
+        if (this.optionalCharacter(chars.$LPAREN)) {
+            this.rparensExpected++;
+            const result = this.parsePipe();
+            this.rparensExpected--;
+            this.expectCharacter(chars.$RPAREN);
+            return result;
+
+        } else if (this.next.isKeywordNull()) {
+            this.advance();
+            return new LiteralPrimitive(this.span(start), null);
+
+        } else if (this.next.isKeywordUndefined()) {
+            this.advance();
+            return new LiteralPrimitive(this.span(start), void 0);
+
+        } else if (this.next.isKeywordTrue()) {
+            this.advance();
+            return new LiteralPrimitive(this.span(start), true);
+
+        } else if (this.next.isKeywordFalse()) {
+            this.advance();
+            return new LiteralPrimitive(this.span(start), false);
+
+        } else if (this.next.isKeywordThis()) {
+            this.advance();
+            return new ImplicitReceiver(this.span(start));
+
+        } else if (this.optionalCharacter(chars.$LBRACKET)) {
+            this.rbracketsExpected++;
+            const elements = this.parseExpressionList(chars.$RBRACKET);
+            this.rbracketsExpected--;
+            this.expectCharacter(chars.$RBRACKET);
+            return new LiteralArray(this.span(start), elements);
+
+        } else if (this.next.isCharacter(chars.$LBRACE)) {
+            return this.parseLiteralMap();
+
+        } else if (this.next.isIdentifier()) {
+            return this.parseAccessMemberOrMethodCall(new ImplicitReceiver(this.span(start)), false);
+
+        } else if (this.next.isNumber()) {
+            const value = this.next.toNumber();
+            this.advance();
+            return new LiteralPrimitive(this.span(start), value);
+
+        } else if (this.next.isString()) {
+            const literalValue = this.next.toString();
+            this.advance();
+            return new LiteralPrimitive(this.span(start), literalValue);
+
+        } else if (this.index >= this.tokens.length) {
+            this.error(`Unexpected end of expression: ${this.input}`);
+            return new EmptyExpr(this.span(start));
+        } else {
+            this.error(`Unexpected token ${this.next}`);
+            return new EmptyExpr(this.span(start));
+        }
+    }
+
+    parseExpressionList(terminator: number): AST[] {
+        const result: AST[] = [];
+        if (!this.next.isCharacter(terminator)) {
+            do {
+                result.push(this.parsePipe());
+            } while (this.optionalCharacter(chars.$COMMA));
+        }
+        return result;
+    }
+
+    parseLiteralMap(): LiteralMap {
+        const keys: string[] = [];
+        const values: AST[] = [];
+        const start = this.inputIndex;
+        this.expectCharacter(chars.$LBRACE);
+        if (!this.optionalCharacter(chars.$RBRACE)) {
+            this.rbracesExpected++;
+            do {
+                const key = this.expectIdentifierOrKeywordOrString();
+                keys.push(key);
+                this.expectCharacter(chars.$COLON);
+                values.push(this.parsePipe());
+            } while (this.optionalCharacter(chars.$COMMA));
+            this.rbracesExpected--;
+            this.expectCharacter(chars.$RBRACE);
+        }
+        return new LiteralMap(this.span(start), keys, values);
+    }
+
+    parseAccessMemberOrMethodCall(receiver: AST, isSafe: boolean = false): AST {
+        const start = receiver.span.start;
+        const id = this.expectIdentifierOrKeyword();
+
+        if (this.optionalCharacter(chars.$LPAREN)) {
+            this.rparensExpected++;
+            const args = this.parseCallArguments();
+            this.expectCharacter(chars.$RPAREN);
+            this.rparensExpected--;
+            const span = this.span(start);
+            return isSafe ? new SafeMethodCall(span, receiver, id, args) :
+                new MethodCall(span, receiver, id, args);
+
+        } else {
+            if (isSafe) {
+                if (this.optionalOperator('=')) {
+                    this.error('The \'?.\' operator cannot be used in the assignment');
+                    return new EmptyExpr(this.span(start));
+                } else {
+                    return new SafePropertyRead(this.span(start), receiver, id);
+                }
+            } else {
+                if (this.optionalOperator('=')) {
+                    if (!this.parseAction) {
+                        this.error('Bindings cannot contain assignments');
+                        return new EmptyExpr(this.span(start));
+                    }
+
+                    const value = this.parseConditional();
+                    return new PropertyWrite(this.span(start), receiver, id, value);
+                } else {
+                    return new PropertyRead(this.span(start), receiver, id);
+                }
+            }
+        }
+    }
+
+    parseCallArguments(): BindingPipe[] {
+        if (this.next.isCharacter(chars.$RPAREN)) return [];
+        const positionals: AST[] = [];
+        do {
+            positionals.push(this.parsePipe());
+        } while (this.optionalCharacter(chars.$COMMA));
+        return positionals as BindingPipe[];
+    }
+
+    /**
+     * An identifier, a keyword, a string with an optional `-` inbetween.
+     */
+    expectTemplateBindingKey(): string {
+        let result = '';
+        let operatorFound = false;
+        do {
+            result += this.expectIdentifierOrKeywordOrString();
+            operatorFound = this.optionalOperator('-');
+            if (operatorFound) {
+                result += '-';
+            }
+        } while (operatorFound);
+
+        return result.toString();
+    }
+
+    parseTemplateBindings(): TemplateBindingParseResult {
+        const bindings: TemplateBinding[] = [];
+        let prefix: string = null;
+        const warnings: string[] = [];
+        while (this.index < this.tokens.length) {
+            const start = this.inputIndex;
+            const keyIsVar: boolean = this.peekKeywordLet();
+            if (keyIsVar) {
+                this.advance();
+            }
+            let key = this.expectTemplateBindingKey();
+            if (!keyIsVar) {
+                if (prefix == null) {
+                    prefix = key;
+                } else {
+                    key = prefix + key[0].toUpperCase() + key.substring(1);
+                }
+            }
+            this.optionalCharacter(chars.$COLON);
+            let name: string = null;
+            let expression: ASTWithSource = null;
+            if (keyIsVar) {
+                if (this.optionalOperator('=')) {
+                    name = this.expectTemplateBindingKey();
+                } else {
+                    name = '\$implicit';
+                }
+            } else if (this.next !== EOF && !this.peekKeywordLet()) {
+                // tslint:disable-next-line:no-shadowed-variable
+                const start = this.inputIndex;
+                const ast = this.parsePipe();
+                const source = this.input.substring(start - this.offset, this.inputIndex - this.offset);
+                expression = new ASTWithSource(ast, source, this.location, this.errors);
+            }
+            bindings.push(new TemplateBinding(this.span(start), key, keyIsVar, name, expression));
+            if (!this.optionalCharacter(chars.$SEMICOLON)) {
+                this.optionalCharacter(chars.$COMMA);
+            }
+        }
+        return new TemplateBindingParseResult(bindings, warnings, this.errors);
+    }
+
+    error(message: string, index: number = null) {
+        this.errors.push(new ParserError(message, this.input, this.locationText(index), this.location));
+        this.skip();
+    }
+
+    private locationText(index: number = null) {
+        if (isBlank(index)) index = this.index;
+        return (index < this.tokens.length) ? `at column ${this.tokens[index].index + 1} in` :
+            `at the end of the expression`;
+    }
+
+    // Error recovery should skip tokens until it encounters a recovery point. skip() treats
+    // the end of input and a ';' as unconditionally a recovery point. It also treats ')',
+    // '}' and ']' as conditional recovery points if one of calling productions is expecting
+    // one of these symbols. This allows skip() to recover from errors such as '(a.) + 1' allowing
+    // more of the AST to be retained (it doesn't skip any tokens as the ')' is retained because
+    // of the '(' begins an '(' <expr> ')' production). The recovery points of grouping symbols
+    // must be conditional as they must be skipped if none of the calling productions are not
+    // expecting the closing token else we will never make progress in the case of an
+    // extraneous group closing symbol (such as a stray ')'). This is not the case for ';' because
+    // parseChain() is always the root production and it expects a ';'.
+
+    // If a production expects one of these token it increments the corresponding nesting count,
+    // and then decrements it just prior to checking if the token is in the input.
+    private skip() {
+        let n = this.next;
+        while (this.index < this.tokens.length && !n.isCharacter(chars.$SEMICOLON) &&
+            (this.rparensExpected <= 0 || !n.isCharacter(chars.$RPAREN)) &&
+            (this.rbracesExpected <= 0 || !n.isCharacter(chars.$RBRACE)) &&
+            (this.rbracketsExpected <= 0 || !n.isCharacter(chars.$RBRACKET))) {
+            if (this.next.isError()) {
+                this.errors.push(
+                    new ParserError(this.next.toString(), this.input, this.locationText(), this.location));
+            }
+            this.advance();
+            n = this.next;
+        }
+    }
+}
+
+class SimpleExpressionChecker implements AstVisitor {
+    static check(ast: AST): string[] {
+        const s = new SimpleExpressionChecker();
+        ast.visit(s);
+        return s.errors;
+    }
+
+    errors: string[] = [];
+
+    visitImplicitReceiver(ast: ImplicitReceiver, context: any) { }
+
+    visitInterpolation(ast: Interpolation, context: any) { }
+
+    visitLiteralPrimitive(ast: LiteralPrimitive, context: any) { }
+
+    visitPropertyRead(ast: PropertyRead, context: any) { }
+
+    visitPropertyWrite(ast: PropertyWrite, context: any) { }
+
+    visitSafePropertyRead(ast: SafePropertyRead, context: any) { }
+
+    visitMethodCall(ast: MethodCall, context: any) { }
+
+    visitSafeMethodCall(ast: SafeMethodCall, context: any) { }
+
+    visitFunctionCall(ast: FunctionCall, context: any) { }
+
+    visitLiteralArray(ast: LiteralArray, context: any) { this.visitAll(ast.expressions); }
+
+    visitLiteralMap(ast: LiteralMap, context: any) { this.visitAll(ast.values); }
+
+    visitBinary(ast: Binary, context: any) { }
+
+    visitPrefixNot(ast: PrefixNot, context: any) { }
+
+    visitConditional(ast: Conditional, context: any) { }
+
+    visitPipe(ast: BindingPipe, context: any) { this.errors.push('pipes'); }
+
+    visitKeyedRead(ast: KeyedRead, context: any) { }
+
+    visitKeyedWrite(ast: KeyedWrite, context: any) { }
+
+    visitAll(asts: any[]): any[] { return asts.map(node => node.visit(this)); }
+
+    visitChain(ast: Chain, context: any) { }
+
+    visitQuote(ast: Quote, context: any) { }
+}

--- a/src/angular-parse/angular/facade.ts
+++ b/src/angular-parse/angular/facade.ts
@@ -1,0 +1,1 @@
+export * from './facade/lang';

--- a/src/angular-parse/angular/facade/lang.ts
+++ b/src/angular-parse/angular/facade/lang.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export interface BrowserNodeGlobal {
+    Object: typeof Object;
+    Array: typeof Array;
+    Map: typeof Map;
+    Set: typeof Set;
+    Date: DateConstructor;
+    RegExp: RegExpConstructor;
+    JSON: typeof JSON;
+    Math: any;  // typeof Math;
+    assert(condition: any): void;
+    Reflect: any;
+    getAngularTestability: Function;
+    getAllAngularTestabilities: Function;
+    getAllAngularRootElements: Function;
+    frameworkStabilizers: Array<Function>;
+    setTimeout: Function;
+    clearTimeout: Function;
+    setInterval: Function;
+    clearInterval: Function;
+    encodeURI: Function;
+}
+
+
+export function getTypeNameForDebugging(type: any): string {
+    return type['name'] || typeof type;
+}
+
+export function isPresent(obj: any): boolean {
+    return obj != null;
+}
+
+export function isBlank(obj: any): boolean {
+    return obj == null;
+}
+
+const STRING_MAP_PROTO = Object.getPrototypeOf({});
+export function isStrictStringMap(obj: any): boolean {
+    return typeof obj === 'object' && obj !== null && Object.getPrototypeOf(obj) === STRING_MAP_PROTO;
+}
+
+export function stringify(token: any): string {
+    if (typeof token === 'string') {
+        return token;
+    }
+
+    if (token == null) {
+        return '' + token;
+    }
+
+    if (token.overriddenName) {
+        return `${token.overriddenName}`;
+    }
+
+    if (token.name) {
+        return `${token.name}`;
+    }
+
+    const res = token.toString();
+    const newLineIndex = res.indexOf('\n');
+    return newLineIndex === -1 ? res : res.substring(0, newLineIndex);
+}
+
+export class NumberWrapper {
+    static parseIntAutoRadix(text: string): number {
+        const result: number = parseInt(text, 10);
+        if (isNaN(result)) {
+            throw new Error('Invalid integer literal when parsing ' + text);
+        }
+        return result;
+    }
+
+    static isNumeric(value: any): boolean { return !isNaN(value - parseFloat(value)); }
+}
+
+// JS has NaN !== NaN
+export function looseIdentical(a: any, b: any): boolean {
+    return a === b || typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b);
+}
+
+export function isJsObject(o: any): boolean {
+    return o !== null && (typeof o === 'function' || typeof o === 'object');
+}
+
+export function print(obj: Error | Object) {
+    // tslint:disable-next-line:no-console
+    console.log(obj);
+}
+
+export function warn(obj: Error | Object) {
+    console.warn(obj);
+}
+
+export function setValueOnPath(global: any, path: string, value: any) {
+    const parts = path.split('.');
+    let obj: any = global;
+    while (parts.length > 1) {
+        const name = parts.shift();
+        if (obj.hasOwnProperty(name) && obj[name] != null) {
+            obj = obj[name];
+        } else {
+            obj = obj[name] = {};
+        }
+    }
+    if (obj === undefined || obj === null) {
+        obj = {};
+    }
+    obj[parts.shift()] = value;
+}
+
+export function isPrimitive(obj: any): boolean {
+    return !isJsObject(obj);
+}
+
+export function escapeRegExp(s: string): string {
+    return s.replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1');
+}

--- a/src/angular-parse/util.ts
+++ b/src/angular-parse/util.ts
@@ -1,0 +1,2 @@
+export * from './util/binary-operations';
+export * from './util/lang';

--- a/src/angular-parse/util/binary-operations.ts
+++ b/src/angular-parse/util/binary-operations.ts
@@ -1,0 +1,17 @@
+export const BinaryOperations = new Map<string, any>([
+    ['==', (left: any, right: any) => left == right],
+    ['===', (left: any, right: any) => left === right],
+    ['!=', (left: any, right: any) => left != right],
+    ['!==', (left: any, right: any) => left !== right],
+    ['&&', (left: any, right: any) => left && right],
+    ['||', (left: any, right: any) => left || right],
+    ['+', (left: any, right: any) => left + right],
+    ['-', (left: any, right: any) => left - right],
+    ['/', (left: any, right: any) => left / right],
+    ['*', (left: any, right: any) => left * right],
+    ['%', (left: any, right: any) => left % right],
+    ['<', (left: any, right: any) => left < right],
+    ['<=', (left: any, right: any) => left <= right],
+    ['>', (left: any, right: any) => left > right],
+    ['>=', (left: any, right: any) => left >= right],
+]);

--- a/src/angular-parse/util/lang.ts
+++ b/src/angular-parse/util/lang.ts
@@ -1,0 +1,15 @@
+export function compileToJSON(json: any) {
+    return JSON.stringify(json).replace(/"/g, '');
+}
+
+export function isPresent(obj: any) {
+    return obj !== null && obj !== undefined;
+}
+
+export function isJsObject(obj: any) {
+    return obj !== null && (typeof obj === 'function' || typeof obj === 'object');
+}
+
+export function isFunction(val: any) {
+    return typeof val === 'function';
+}

--- a/src/angular-parse/visitors.ts
+++ b/src/angular-parse/visitors.ts
@@ -1,0 +1,2 @@
+export * from './visitors/parse-visitor-compiler';
+export * from './visitors/parse-visitor-resolver';

--- a/src/angular-parse/visitors/parse-visitor-compiler.ts
+++ b/src/angular-parse/visitors/parse-visitor-compiler.ts
@@ -1,0 +1,149 @@
+import {
+    AST,
+    RecursiveAstVisitor,
+    PropertyRead,
+    MethodCall,
+    KeyedRead,
+    ImplicitReceiver,
+    LiteralPrimitive,
+    Binary,
+    Chain,
+    Conditional,
+    BindingPipe,
+    FunctionCall,
+    Interpolation,
+    KeyedWrite,
+    LiteralArray,
+    LiteralMap,
+    PrefixNot,
+    PropertyWrite,
+    SafePropertyRead,
+    SafeMethodCall,
+    Quote
+} from '../angular';
+import { compileToJSON } from '../util';
+
+export class ParseVisitorCompiler extends RecursiveAstVisitor {
+
+    visitBinary(ast: Binary): any {
+        const left = ast.left.visit(this);
+        const right = ast.right.visit(this);
+
+        return `${left} ${ast.operation} ${right}`;
+    }
+
+    // TODO
+    visitChain(ast: Chain): any {
+        return compileToJSON(this.visitAll(ast.expressions));
+    }
+
+    visitConditional(ast: Conditional): any {
+        const condition = ast.condition.visit(this);
+        const trueExp = ast.trueExp.visit(this);
+        const falseExp = ast.falseExp.visit(this);
+
+        return `${condition} ? ${trueExp} : ${falseExp}`;
+    }
+
+    visitPipe(ast: BindingPipe): any {
+        const pipe = ast.name;
+        const args = this.visitAll(ast.args);
+        const value = ast.exp.visit(this);
+        args.unshift(value);
+
+        return `pipesCache.get('${pipe}').transform.apply(null, ${compileToJSON(args)})`;
+    }
+
+    // TODO
+    visitFunctionCall(ast: FunctionCall): any {
+        const target = ast.target.visit(this);
+        const args = compileToJSON(this.visitAll(ast.args));
+
+        return `${target}.apply(${target}, ${args})`;
+    }
+
+    visitImplicitReceiver(ast: ImplicitReceiver): any {
+        return `context`;
+    }
+
+    visitInterpolation(ast: Interpolation): any {
+        return this.visitAll(ast.expressions)[0];
+    }
+
+    visitKeyedRead(ast: KeyedRead): any {
+        const obj = ast.obj.visit(this);
+        const key = ast.key.visit(this);
+
+        return `${obj}[${key}]`;
+    }
+
+    visitKeyedWrite(ast: KeyedWrite): any {
+        return null;
+    }
+
+    visitLiteralArray(ast: LiteralArray): any {
+        return compileToJSON(this.visitAll(ast.expressions));
+    }
+
+    visitLiteralMap(ast: LiteralMap): any {
+        const result = {};
+        const keys = ast.keys;
+        const values = this.visitAll(ast.values);
+
+        for (let i = 0, length = keys.length; i < length; i++) {
+            result[keys[i]] = values[i];
+        }
+
+        return compileToJSON(result);
+    }
+
+    visitLiteralPrimitive(ast: LiteralPrimitive): any {
+        return typeof ast.value === 'string' ? `'${ast.value}'` : ast.value;
+    }
+
+    visitMethodCall(ast: MethodCall): any {
+        const methodName = ast.name;
+        const receiver = ast.receiver.visit(this);
+        const args = compileToJSON(this.visitAll(ast.args));
+
+        return `${receiver}['${methodName}'].apply(${receiver}, ${args})`;
+    }
+
+    visitPrefixNot(ast: PrefixNot): any {
+        return ast.expression.visit(this);
+    }
+
+    visitPropertyRead(ast: PropertyRead): any {
+        const property = ast.name;
+        const receiver = ast.receiver.visit(this);
+
+        return `${receiver}['${property}']`;
+    }
+
+    visitPropertyWrite(ast: PropertyWrite): any {
+        return null;
+    }
+
+    visitSafePropertyRead(ast: SafePropertyRead): any {
+        const property = ast.name;
+        const receiver = ast.receiver.visit(this);
+
+        return `${receiver}['${property}']`;
+    }
+
+    visitSafeMethodCall(ast: SafeMethodCall): any {
+        const methodName = ast.name;
+        const receiver = ast.receiver.visit(this);
+        const args = compileToJSON(this.visitAll(ast.args));
+
+        return `${receiver}['${methodName}'].apply(${receiver}, ${args})`;
+    }
+
+    visitAll(asts: AST[]): any {
+        return asts.map(ast => ast.visit(this));
+    }
+
+    visitQuote(ast: Quote): any {
+        return null;
+    }
+}

--- a/src/angular-parse/visitors/parse-visitor-resolver.ts
+++ b/src/angular-parse/visitors/parse-visitor-resolver.ts
@@ -1,0 +1,208 @@
+import {
+    AST,
+    RecursiveAstVisitor,
+    PropertyRead,
+    MethodCall,
+    KeyedRead,
+    ImplicitReceiver,
+    LiteralPrimitive,
+    Binary,
+    Chain,
+    Conditional,
+    BindingPipe,
+    FunctionCall,
+    Interpolation,
+    KeyedWrite,
+    LiteralArray,
+    LiteralMap,
+    PrefixNot,
+    PropertyWrite,
+    SafePropertyRead,
+    SafeMethodCall,
+    Quote
+} from '../angular';
+import * as util from '../util';
+import { BinaryOperations } from '../util/binary-operations';
+
+export class ParseVisitorResolver extends RecursiveAstVisitor {
+
+    constructor(private pipes: Map<string, any>) {
+        super();
+    };
+
+    visitBinary(ast: Binary, context: any): any {
+        const execFn = BinaryOperations.get(ast.operation);
+
+        if (!execFn) {
+            throw new Error(`Parse ERROR: on visitBinary, unknown operator ${ast.operation}`);
+        }
+
+        return execFn(ast.left.visit(this, context), ast.right.visit(this, context));
+    }
+
+    // TODO
+    visitChain(ast: Chain, context: any): any {
+        return this.visitAll(ast.expressions, context);
+    }
+
+    visitConditional(ast: Conditional, context: any): any {
+        if (ast.condition.visit(this, context)) {
+            return ast.trueExp.visit(this, context);
+        }
+        else if (util.isPresent(ast.falseExp)) {
+            return ast.falseExp.visit(this, context);
+        }
+
+        return null;
+    }
+
+    visitPipe(ast: BindingPipe, context: any): any {
+        const pipe = this.pipes.get(ast.name);
+
+        if (!pipe) {
+            throw new Error(`pipe ${ast.name} not found.`);
+        }
+
+        if (!pipe.transform) {
+            throw new Error(`Parse ERROR: on visitPipe, transform method doesn't exist on pipe ${ast.name}.`);
+        }
+
+        const value = ast.exp.visit(this, context);
+        const pipeArgs = this.visitAll(ast.args, context);
+
+        pipeArgs.unshift(value);
+
+        return pipe.transform.apply(null, pipeArgs);
+    }
+
+    // TODO
+    visitFunctionCall(ast: FunctionCall, context: any): any {
+        const target = ast.target.visit(this, context);
+
+        if (!util.isFunction(target)) {
+            throw new Error(`Parse ERROR: on visitFunctionCall, target is not a function.`);
+        }
+
+        const args = this.visitAll(ast.args, context);
+        return target.apply(target, args);
+    }
+
+    visitImplicitReceiver(ast: ImplicitReceiver, context: any): any {
+        return context;
+    }
+
+    visitInterpolation(ast: Interpolation, context: any): any {
+        return this.visitAll(ast.expressions, context)[0];
+    }
+
+    visitKeyedRead(ast: KeyedRead, context: any): any {
+        const obj = ast.obj.visit(this, context);
+        const key = ast.key.visit(this, context);
+        return obj[key];
+    }
+
+    visitKeyedWrite(ast: KeyedWrite, context: any): any {
+        const obj = ast.obj.visit(this, context);
+        const key = ast.key.visit(this, context);
+        const value = ast.value.visit(this, context);
+        obj[key] = value;
+        return null;
+    }
+
+    visitLiteralArray(ast: LiteralArray, context: any): any {
+        return this.visitAll(ast.expressions, context);
+    }
+
+    visitLiteralMap(ast: LiteralMap, context: any): any {
+        const result = {};
+        const keys = ast.keys;
+        const values = this.visitAll(ast.values, context);
+
+        for (let i = 0, length = keys.length; i < length; i++) {
+            result[keys[i]] = values[i];
+        }
+
+        return result;
+    }
+
+    visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any {
+        return ast.value;
+    }
+
+    visitMethodCall(ast: MethodCall, context: any): any {
+        const receiver = ast.receiver.visit(this, context);
+
+        if (!util.isJsObject(receiver)) {
+            throw new Error(`Parse ERROR: on visitMethodCall, invalid method receiver.`);
+        }
+
+        const method = receiver[ast.name];
+
+        if (!util.isFunction(method)) {
+            throw new Error(`Parse ERROR: on visitMethodCall, method ${ast.name} doesn't exist on receiver.`);
+        }
+
+        const args = this.visitAll(ast.args, context);
+        return method.apply(receiver, args);
+    }
+
+    visitPrefixNot(ast: PrefixNot, context: any): any {
+        return ast.expression.visit(this, context);
+    }
+
+    visitPropertyRead(ast: PropertyRead, context: any): any {
+        const receiver = ast.receiver.visit(this, context);
+
+        if (!util.isJsObject(receiver)) {
+            throw new Error(`Parse ERROR: on visitPropertyRead, invalid property receiver.`);
+        }
+
+        return receiver[ast.name];
+    }
+
+    visitPropertyWrite(ast: PropertyWrite, context: any): any {
+        const receiver = ast.receiver.visit(this, context);
+
+        if (!util.isJsObject(receiver)) {
+            throw new Error(`Parse ERROR: on visitPropertyRead, invalid property receiver.`);
+        }
+
+        receiver[ast.name] = ast.value.visit(this, context);
+        return null;
+    }
+
+    visitSafePropertyRead(ast: SafePropertyRead, context: any): any {
+        const receiver = ast.receiver.visit(this, context);
+
+        if (!util.isJsObject(receiver)) {
+            throw new Error(`Parse ERROR: on visitSafePropertyRead, invalid property receiver.`);
+        }
+
+        return receiver[ast.name];
+    }
+
+    visitSafeMethodCall(ast: SafeMethodCall, context: any): any {
+        const receiver = ast.receiver.visit(this, context);
+
+        if (!util.isJsObject(receiver)) {
+            throw new Error(`Parse ERROR: on visitSafeMethodCall, invalid method receiver.`);
+        }
+
+        const method = receiver[ast.name];
+
+        if (!util.isFunction(method)) {
+            throw new Error(`Parse ERROR: on visitSafeMethodCall, method ${ast.name} doesn't exist on receiver.`);
+        }
+
+        const args = this.visitAll(ast.args, context);
+        return method.apply(receiver, args);
+    }
+
+    visitAll(asts: AST[], context: any): any {
+        return asts.map(ast => ast.visit(this, context));
+    }
+
+    visitQuote(ast: Quote, context: any): any {
+        throw new Error(`Parse ERROR: on visitQuote, quote expression not allowed.`);
+    }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -9,10 +9,16 @@
       true,
       "check-space"
     ],
-    "curly": true,
+    "curly": [
+      true,
+      "ignore-same-line"
+    ],
     "eofline": true,
     "forin": true,
-    "import-blacklist": [true, "rxjs"],
+    "import-blacklist": [
+      true,
+      "rxjs"
+    ],
     "import-spacing": true,
     "indent": [
       true
@@ -25,7 +31,8 @@
     ],
     "member-access": false,
     "member-ordering": [
-      true, "static-before-instance"
+      true,
+      "static-before-instance"
     ],
     "no-arg": true,
     "no-bitwise": true,
@@ -43,7 +50,10 @@
     "no-empty": false,
     "no-empty-interface": true,
     "no-eval": true,
-    "no-inferrable-types": [true, "ignore-params"],
+    "no-inferrable-types": [
+      true,
+      "ignore-params"
+    ],
     "no-shadowed-variable": true,
     "no-string-literal": false,
     "no-string-throw": true,
@@ -69,7 +79,7 @@
       "always"
     ],
     "triple-equals": [
-      true,
+      false,
       "allow-null-check"
     ],
     "typedef-whitespace": [
@@ -93,10 +103,23 @@
       "check-separator",
       "check-type"
     ],
-
-    "angular-whitespace": [true, "check-interpolation", "check-semicolon"],
-    "directive-selector": [true, "attribute", "", "camelCase"],
-    "component-selector": [true, "element", "", "kebab-case"],
+    "angular-whitespace": [
+      true,
+      "check-interpolation",
+      "check-semicolon"
+    ],
+    "directive-selector": [
+      true,
+      "attribute",
+      "",
+      "camelCase"
+    ],
+    "component-selector": [
+      true,
+      "element",
+      "",
+      "kebab-case"
+    ],
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-host-property-decorator": true,
@@ -106,7 +129,13 @@
     "use-pipe-transform-interface": true,
     "no-attribute-parameter-decorator": true,
     "no-output-on-prefix": false,
-    "component-class-suffix": [true, "Component"],
-    "directive-class-suffix": [true, "Directive"]
+    "component-class-suffix": [
+      true,
+      "Component"
+    ],
+    "directive-class-suffix": [
+      true,
+      "Directive"
+    ]
   }
 }


### PR DESCRIPTION
This PR aims to solve #224 

**Problem**
Due to changes in AOT Compiler introduced with Angular 6, angular-cesium crashes when built with aot.

The error is in a dependency of angular-cesium: [angular2parse](https://github.com/TGFTech/angular2parse), another TGFTech library.

More specifically the problem is how Angular Compiler is used [here](https://github.com/TGFTech/angular2parse/blob/29ab3eebdab4e873cb19cf623bdf0d9e2267baf0/src/parse.ts#L17).

This piece of code gets all Angular Pipes injected by the active module in order to parse the properties of AcEntities. The new Ng6 AOT Compiler does not provide access to the Angular Pipes anymore.

The problem is blocking any production use of Angular 6 application using angular-cesium. 

**Solution**
I did not find a solution to reproduce the same behavior with Angular 6 AOT Compiler. Using the Compiler in this way is probably not the best way anyways.

The only solution I found was to inject the pipes manually. In order to simplify the development process I dropped the dependency of angular2parse and integrated the needed code directly to angular-cesium.

The important part is in the constructor and the new `_eval()` method of `CesiumPropertyService`

There may be better solutions, but for the moment it does the job, at least for me.