### PR TITLE
Fix AOT for angular 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## NEXT 
+### Fixes
+* Fixed AOT compilation for angular 6, the issue was with `angular2parse` reaching angular compiler pipes.  
+
+### Breaking Changes
+* From now Angular Pipes need to be set in `AngularCesiumModule.forRoot(ustomPipes: myCustomPipes)`.
+angular-cesium won't be aware of pipes that wont be defined as `customPipes`.
+There for any user Pipes need to be declared when initializing angular cesium. 
+
 ## 0.0.52
 ### Fixes
 * Fixed shape editors 2D points bug - remove height reference

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "postpublish": "npm run docs:push"
   },
   "peerDependencies": {
-    "@angular/common": "^4.2.6 || ^5.0.0",
-    "@angular/core": "^4.2.6 || ^5.0.0"
+    "@angular/common": "^4.2.6 || ^5.0.0 || ^6.0.0",
+    "@angular/core": "^4.2.6 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@angular/animations": "5.1.0",
@@ -142,7 +142,7 @@
   },
   "dependencies": {
     "@types/geodesy": "^1.1.2",
-    "angular2parse": "^1.0.5",
+    "angular2parse": "^1.0.6",
     "geodesy": "^1.1.1",
     "json-string-mapper": "^1.0.0",
     "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   },
   "dependencies": {
     "@types/geodesy": "^1.1.2",
-    "angular2parse": "^1.0.6",
+    "angular2parse": "^1.0.7",
     "geodesy": "^1.1.1",
     "json-string-mapper": "^1.0.0",
     "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   },
   "dependencies": {
     "@types/geodesy": "^1.1.2",
-    "angular2parse": "^1.0.7",
+    "angular2parse": "^1.0.8",
     "geodesy": "^1.1.1",
     "json-string-mapper": "^1.0.0",
     "lodash.get": "^4.4.2",

--- a/src/angular-cesium/angular-cesium.module.ts
+++ b/src/angular-cesium/angular-cesium.module.ts
@@ -6,7 +6,7 @@ import { AcBillboardComponent } from './components/ac-billboard/ac-billboard.com
 import { AcBillboardDescComponent } from './components/ac-billborad-desc/ac-billborad-desc.component';
 import { AcEllipseDescComponent } from './components/ac-ellipse-desc/ac-ellipse-desc.component';
 import { AcPolylineDescComponent } from './components/ac-polyline-desc/ac-polyline-desc.component';
-import { Angular2ParseModule } from 'angular2parse';
+import { Angular2ParseModule, PIPES_CONFIG } from 'angular2parse';
 import { PixelOffsetPipe } from './pipes/pixel-offset/pixel-offset.pipe';
 import { RadiansToDegreesPipe } from './pipes/radians-to-degrees/radians-to-degrees.pipe';
 import { JsonMapper } from './services/json-mapper/json-mapper.service';
@@ -59,11 +59,13 @@ import { AcContextMenuWrapperComponent } from './components/ac-context-menu-wrap
 import { AcArrayDescComponent } from './components/ac-array-desc/ac-array-desc.component';
 import { AcPointPrimitiveDescComponent } from './components/ac-point-primitive-desc/ac-point-primitive-desc.component';
 import { AcPrimitivePolylineComponent } from './components/ac-primitive-polyline/ac-primitive-polyline.component';
+import PARSE_PIPES_CONFIG_MAP from './pipes/pipe-config-map';
+
 
 @NgModule({
   imports: [
     CommonModule,
-    Angular2ParseModule,
+    Angular2ParseModule.forRoot(PARSE_PIPES_CONFIG_MAP),
     UtilsModule,
   ],
   declarations: [
@@ -156,7 +158,7 @@ import { AcPrimitivePolylineComponent } from './components/ac-primitive-polyline
     AcWallDescComponent,
     AcRectangleDescComponent,
     AcContextMenuWrapperComponent,
-		AcPointPrimitiveDescComponent,
+    AcPointPrimitiveDescComponent,
     AcHtmlDescComponent,
     AcArrayDescComponent,
 
@@ -174,7 +176,10 @@ export class AngularCesiumModule {
   static forRoot(config?: ModuleConfiguration): ModuleWithProviders {
     return {
       ngModule: AngularCesiumModule,
-      providers: [{provide: ANGULAR_CESIUM_CONFIG, useValue: config}]
+      providers: [
+        { provide: ANGULAR_CESIUM_CONFIG, useValue: config },
+        { provide: PIPES_CONFIG, multi: true, useValue:  config && config.customPipes || []},
+      ],
     };
   }
 

--- a/src/angular-cesium/models/module-options.ts
+++ b/src/angular-cesium/models/module-options.ts
@@ -1,7 +1,9 @@
 /**
  * The interface defines the options object that can be passed to AngularCesiumModule on initialization.
  */
+import { PipesConfig } from 'angular2parse';
 
 export interface ModuleConfiguration {
   fixEntitiesShadows?: boolean;
+  customPipes: PipesConfig[];
 }

--- a/src/angular-cesium/pipes.ts
+++ b/src/angular-cesium/pipes.ts
@@ -1,1 +1,2 @@
 export * from './pipes/pixel-offset/pixel-offset.pipe';
+export * from './pipes/radians-to-degrees/radians-to-degrees.pipe';

--- a/src/angular-cesium/pipes/pipe-config-map.ts
+++ b/src/angular-cesium/pipes/pipe-config-map.ts
@@ -1,0 +1,8 @@
+import { PixelOffsetPipe } from './pixel-offset/pixel-offset.pipe';
+import { RadiansToDegreesPipe } from './radians-to-degrees/radians-to-degrees.pipe';
+
+// For angular parse usage
+export default [
+  { pipeName: 'pixelOffset', pipeInstance: new PixelOffsetPipe() },
+  { pipeName: 'radiansToDegrees', pipeInstance: new RadiansToDegreesPipe() },
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,9 +323,9 @@ angular2-template-loader@^0.6.0:
   dependencies:
     loader-utils "^0.2.15"
 
-angular2parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/angular2parse/-/angular2parse-1.0.6.tgz#27acc6669a49117b64610e293f9cfd33c840bbfb"
+angular2parse@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/angular2parse/-/angular2parse-1.0.8.tgz#4e2516bb8ca76ce3e3516a6ed6f62de65472a828"
 
 ansi-align@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,7 +323,7 @@ angular2-template-loader@^0.6.0:
   dependencies:
     loader-utils "^0.2.15"
 
-angular2parse@^1.0.5:
+angular2parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/angular2parse/-/angular2parse-1.0.6.tgz#27acc6669a49117b64610e293f9cfd33c840bbfb"
 


### PR DESCRIPTION
angular2parse reaching angular's pipe cache caused the issue. 
now pipes need to be defined by the user. 

wait for angular2parse PR.

fix #224 